### PR TITLE
Infer description for input params

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -66,6 +66,7 @@ export const getParameterObjects = (schema: unknown): OpenAPIV3.ParameterObject[
       in: 'query',
       required: !value.isOptional(),
       schema: zodSchemaToOpenApiSchemaObject(value),
+      description: value.description,
       style: 'form',
       explode: true,
     };


### PR DESCRIPTION
This allows to use the `.describe()` zod method to specify human-readable descriptions for input props.

Doing this:
```tsx
  input: z.object({
    id: z.string().uuid().describe("UUID of the user."),
  }),
```

Results in this:
<img width="560" alt="Screenshot 2022-05-28 at 03 17 01" src="https://user-images.githubusercontent.com/14360171/170804183-f84404c6-fb5a-4f41-950a-c6b0dc6ecdf9.png">

