### PR TITLE
WIP: Support OpenAPI `path` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
 
 **5. Add an `trpc-openapi` handler to your app.**
 
-We currently support adapters for `Express`, `Next.js` & `node:http`. `Fastify` & `Serverless` soon™.
+We currently support adapters for [`Express`](http://expressjs.com/), [`Next.js`](https://nextjs.org/) & [`node:http`](https://nodejs.org/api/http.html). [`Fastify`](https://www.fastify.io/) & [`Serverless`](https://www.serverless.com/) soon™.
 
 ```typescript
 import http from 'http';

--- a/README.md
+++ b/README.md
@@ -160,7 +160,17 @@ const res = await fetch('http://localhost:3000/say-hello', {
 const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' } } */
 ```
 
-## API Responses
+## HTTP Requests
+
+### Path parameters
+
+You can add path parameters to any OpenAPI enabled procedure by using curly
+
+### Query parameters
+
+### Request body
+
+## HTTP Responses
 
 Inspired by [Slack Web API](https://api.slack.com/web).
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 ## HTTP Requests
 
-Query procedures accept inputs via URL query parameters. Mutation procedures accept inputs via the request body as an `application/json` content type. Additionally, both queries & mutations can accept a set of their inputs via URL path parameters. You can add a path parameter to any OpenAPI enabled procedure by using curly brackets around an input name as a path segment in the `meta.openapi.path` field.
+Query procedures accept inputs via URL query parameters.
+
+Mutation procedures accept inputs via the request body as an `application/json` content type.
+
+Both queries & mutations can accept a set of their inputs via URL path parameters. You can add a path parameter to any OpenAPI enabled procedure by using curly brackets around an input name as a path segment in the `meta.openapi.path` field.
 
 #### Query
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Please note:
 
 - Data [`transformers`](https://trpc.io/docs/data-transformers) are ignored.
 - Trailing slashes are ignored.
+- Routing is case-insensitive.
 
 ## Authorization
 
@@ -164,11 +165,16 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 ### Path parameters
 
+TODO:
 You can add path parameters to any OpenAPI enabled procedure by using curly
 
 ### Query parameters
 
+TODO:
+
 ### Request body
+
+TODO:
 
 ## HTTP Responses
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Please note:
 
 ## Authorization
 
-To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request with the `createContext` function in your handler's options using the `Authorization` header with the `Bearer` scheme (e.g. `Bearer {{token}}`).
+To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request with the `createContext` function using the `Authorization` header with the `Bearer` scheme.
 
 Explore a [complete example here](examples/with-nextjs/src/server/router.ts).
 
@@ -213,7 +213,7 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 Inspired by [Slack Web API](https://api.slack.com/web).
 
-Status codes will be `200` by default for any successful requests. In the case of an error, the status code will be derived from the thrown `TRPCError` or fallback to `500`, please see [error status codes here](src/adapters/node-http/errors.ts). You can modify the each response status code using the `responseMeta` function in your handler's options.
+Status codes will be `200` by default for any successful requests. In the case of an error, the status code will be derived from the thrown `TRPCError` or fallback to `500`, please see [error status codes here](src/adapters/node-http/errors.ts). You can modify the each responses status code using the `responseMeta` function.
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 Inspired by [Slack Web API](https://api.slack.com/web).
 
-Status codes will be `200` by default for any successful requests. In the case of an error, the status code will be derived from the thrown `TRPCError` or fallback to `500`, please see [error status codes here](src/adapters/node-http/errors.ts). You can modify the each responses status code using the `responseMeta` function.
+Status codes will be `200` by default for any successful requests. In the case of an error, the status code will be derived from the thrown `TRPCError` or fallback to `500`. You can modify the each responses status code using the `responseMeta` function.
+
+Please see [error status codes here](src/adapters/node-http/errors.ts).
 
 ```jsonc
 {
@@ -270,7 +272,7 @@ export default createOpenApiNextHandler({ router: appRouter });
 
 #### OpenApiMeta
 
-Please see full typings [here](src/types.ts).
+Please see [full typings here](src/types.ts).
 
 | Property      | Type         | Description                                                                                                            | Required | Default     |
 | ------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
@@ -284,7 +286,7 @@ Please see full typings [here](src/types.ts).
 
 #### GenerateOpenApiDocumentOptions
 
-Please see full typings [here](src/generator/index.ts).
+Please see [full typings here](src/generator/index.ts).
 
 | Property      | Type     | Description                          | Required |
 | ------------- | -------- | ------------------------------------ | -------- |
@@ -296,7 +298,7 @@ Please see full typings [here](src/generator/index.ts).
 
 #### CreateOpenApiNodeHttpHandlerOptions
 
-Please see full typings [here](src/adapters/node-http/core.ts).
+Please see [full typings here](src/adapters/node-http/core.ts).
 
 | Property        | Type       | Description                                                                   | Required |
 | --------------- | ---------- | ----------------------------------------------------------------------------- | -------- |

--- a/README.md
+++ b/README.md
@@ -95,13 +95,12 @@ For every OpenAPI enabled procedure the following _must_ be true:
 - Parsers use [`Zod`](https://github.com/colinhacks/zod) validation.
 - Query `input` parsers extend `ZodObject<{ [string]: ZodString }>`.
 - Mutation `input` parsers extend `ZodObject<{ [string]: ZodType }>`.
-- `meta.openapi` object has the following keys.
-  - `.enabled` is set to `true`.
-  - `.method` is `GET` or `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
-  - `.path` is a string starting with `/`.
-  - `.path` parameters exist in `input` parser as `ZodString`
+- `meta.openapi.enabled` is set to `true`.
+- `meta.openapi.method` is `GET` or `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
+- `meta.openapi.path` is a string starting with `/`.
+- `meta.openapi.path` parameters exist in `input` parser as `ZodString`
 
-Note:
+Please note:
 
 - Data [`transformers`](https://trpc.io/docs/data-transformers) are ignored.
 - Trailing slashes are ignored.

--- a/README.md
+++ b/README.md
@@ -163,18 +163,47 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 ## HTTP Requests
 
-### Path parameters
+Query procedures accept inputs via URL query parameters. Mutation procedures accept inputs via the request body as an `application/json` content type. Additionally, both `queries` & `mutations` can accept a set of their inputs via URL path parameters. You can add path parameters to any OpenAPI enabled procedure by using curly brackets around a path segment input name in the `meta.openapi.path` field.
 
-TODO:
-You can add path parameters to any OpenAPI enabled procedure by using curly
+#### Query
 
-### Query parameters
+```typescript
+// Router
+export const appRouter = trpc.router<Context, OpenApiMeta>().query('sayHello', {
+  meta: { openapi: { enabled: true, method: 'GET', path: '/say-hello/{name}' /* 👈 */ } },
+  input: z.object({ name: z.string(), greeting: z.string() }),
+  output: z.object({ greeting: z.string() }),
+  resolve: ({ input }) => {
+    return { greeting: `${input.greeting} ${input.name}!` };
+  },
+});
 
-TODO:
+// Client
+const res = await fetch('http://localhost:3000/say-hello/James?greeting=Hello', { method: 'GET' });
+const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' } } */
+```
 
-### Request body
+#### Mutation
 
-TODO:
+```typescript
+// Router
+export const appRouter = trpc.router<Context, OpenApiMeta>().mutation('sayHello', {
+  meta: { openapi: { enabled: true, method: 'GET', path: '/say-hello/{name}' /* 👈 */ } },
+  input: z.object({ name: z.string(), greeting: z.string() }),
+  output: z.object({ greeting: z.string() }),
+  resolve: ({ input }) => {
+    return { greeting: `${input.greeting} ${input.name}!` };
+  },
+});
+
+// Client
+const res = await fetch('http://localhost:3000/say-hello/James', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ greeting: 'Hello' }),
+});
+const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' } } */
+```
 
 ## HTTP Responses
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
 
 **5. Add an `trpc-openapi` handler to your app.**
 
-We currently support adapters for `Express`, `Next.js` & `node:http` (`Fastify` & `Serverless` soon™).
+We currently support adapters for `Express`, `Next.js` & `node:http`. `Fastify` & `Serverless` soon™.
 
 ```typescript
 import http from 'http';
@@ -108,7 +108,7 @@ Please note:
 
 ## Authorization
 
-To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request in `createContext` function using the `Authorization` header with the `Bearer` scheme.
+To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request with the `createContext` function in your handler's options using the `Authorization` header with the `Bearer` scheme (e.g. `Bearer {{token}}`).
 
 Explore a [complete example here](examples/with-nextjs/src/server/router.ts).
 

--- a/README.md
+++ b/README.md
@@ -91,20 +91,23 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 For every OpenAPI enabled procedure the following _must_ be true:
 
 - [`tRPC`](https://github.com/trpc/trpc) version 9 (`@trpc/server@^9.23.0`) is installed.
-- `meta.openapi.enabled` is set to `true`.
-- `meta.openapi.method` is `GET` or `DELETE` for query OR `POST`, `PUT` or `PATCH` for mutation procedures.
-- `meta.openapi.path` is a string starting with `/`.
 - Both `input` and `output` parsers are present.
 - Parsers use [`Zod`](https://github.com/colinhacks/zod) validation.
-- `input` parsers extend `Record<string, string>`.
+- Query `input` parsers extend `ZodObject<{ [string]: ZodString }>`.
+- Mutation `input` parsers extend `ZodObject<{ [string]: ZodType }>`.
+- `meta.openapi.enabled` is set to `true`.
+- `meta.openapi.method` is `GET` or `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
+- `meta.openapi.path` is a string starting with `/`.
+- `meta.openapi.path` parameters are specified using `{}`.
+- `meta.openapi.path` parameters are present in `input` parser as `ZodString`
 
-Please note that data [`transformer`](https://trpc.io/docs/data-transformers)s attached to your router are ignored by `trpc-openapi`.
+Note that data [`transformers`](https://trpc.io/docs/data-transformers) are ignored by `trpc-openapi`.
 
 ## Authorization
 
 To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request in `createContext` function using the `Authorization` header with the `Bearer` scheme.
 
-Please explore a [complete example here](examples/with-nextjs/src/server/router.ts).
+Explore a [complete example here](examples/with-nextjs/src/server/router.ts).
 
 #### Server
 
@@ -170,7 +173,7 @@ Inspired by [Slack Web API](https://api.slack.com/web).
 {
   "ok": false,
   "error": {
-    "message": "This is bad" /* error.message */,
+    "message": "This is bad" /* TRPCError message */,
     "code": "BAD_REQUEST" /* TRPCError code */
   }
 }
@@ -220,7 +223,7 @@ Please see full typings [here](src/types.ts).
 | --------- | ------------ | ------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
 | `enabled` | `boolean`    | Exposes procedure to `trpc-openapi` adapters and in OpenAPI document                                                | `true`   | `false`     |
 | `method`  | `HttpMethod` | Method this route is exposed on. Value can be `GET` or `DELETE` for query OR `POST`, `PUT` or `PATCH` for mutation. | `true`   | `undefined` |
-| `path`    | `string`     | Path this route is exposed on. Value must start with `/`.                                                           | `true`   | `undefined` |
+| `path`    | `string`     | Route this endpoint is exposed on. Value must start with `/`. Specify parameters using `{}`.                        | `true`   | `undefined` |
 | `protect` | `boolean`    | Requires this route to have an `Authorization` header credential using the `Bearer` scheme on OpenAPI document.     | `false`  | `false`     |
 | `summary` | `string`     | Route summary included in OpenAPI document.                                                                         | `false`  | `undefined` |
 | `tags`    | `string[]`   | Route tags included in OpenAPI document.                                                                            | `false`  | `[]`        |

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ export const openApiDocument = generateOpenApiDocument(appRouter, {
 });
 ```
 
-**5. Add an `trpc-openapi` adapter to your app.**
+**5. Add an `trpc-openapi` handler to your app.**
 
-Current support for `Express`, `Next.js` & `node:http`.
+We currently support adapters for `Express`, `Next.js` & `node:http` (`Fastify` & `Serverless` soon™).
 
 ```typescript
 import http from 'http';
@@ -163,7 +163,7 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 ## HTTP Requests
 
-Query procedures accept inputs via URL query parameters. Mutation procedures accept inputs via the request body as an `application/json` content type. Additionally, both `queries` & `mutations` can accept a set of their inputs via URL path parameters. You can add path parameters to any OpenAPI enabled procedure by using curly brackets around a path segment input name in the `meta.openapi.path` field.
+Query procedures accept inputs via URL query parameters. Mutation procedures accept inputs via the request body as an `application/json` content type. Additionally, both queries & mutations can accept a set of their inputs via URL path parameters. You can add a path parameter to any OpenAPI enabled procedure by using curly brackets around an input name as a path segment in the `meta.openapi.path` field.
 
 #### Query
 
@@ -171,7 +171,7 @@ Query procedures accept inputs via URL query parameters. Mutation procedures acc
 // Router
 export const appRouter = trpc.router<Context, OpenApiMeta>().query('sayHello', {
   meta: { openapi: { enabled: true, method: 'GET', path: '/say-hello/{name}' /* 👈 */ } },
-  input: z.object({ name: z.string(), greeting: z.string() }),
+  input: z.object({ name: z.string() /* 👈 */, greeting: z.string() }),
   output: z.object({ greeting: z.string() }),
   resolve: ({ input }) => {
     return { greeting: `${input.greeting} ${input.name}!` };
@@ -179,7 +179,7 @@ export const appRouter = trpc.router<Context, OpenApiMeta>().query('sayHello', {
 });
 
 // Client
-const res = await fetch('http://localhost:3000/say-hello/James?greeting=Hello', { method: 'GET' });
+const res = await fetch('http://localhost:3000/say-hello/James?greeting=Hello' /* 👈 */, { method: 'GET' });
 const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' } } */
 ```
 
@@ -189,7 +189,7 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 // Router
 export const appRouter = trpc.router<Context, OpenApiMeta>().mutation('sayHello', {
   meta: { openapi: { enabled: true, method: 'GET', path: '/say-hello/{name}' /* 👈 */ } },
-  input: z.object({ name: z.string(), greeting: z.string() }),
+  input: z.object({ name: z.string() /* 👈 */, greeting: z.string() }),
   output: z.object({ greeting: z.string() }),
   resolve: ({ input }) => {
     return { greeting: `${input.greeting} ${input.name}!` };
@@ -197,7 +197,7 @@ export const appRouter = trpc.router<Context, OpenApiMeta>().mutation('sayHello'
 });
 
 // Client
-const res = await fetch('http://localhost:3000/say-hello/James', {
+const res = await fetch('http://localhost:3000/say-hello/James' /* 👈 */, {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
   body: JSON.stringify({ greeting: 'Hello' }),
@@ -208,6 +208,8 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 ## HTTP Responses
 
 Inspired by [Slack Web API](https://api.slack.com/web).
+
+Status codes will be `200` by default for any successful requests. In the case of an error, the status code will be derived from the thrown `TRPCError` or fallback to `500`, please see [error status codes here](src/adapters/node-http/errors.ts). You can modify the each response status code using the `responseMeta` function in your handler's options.
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -95,13 +95,16 @@ For every OpenAPI enabled procedure the following _must_ be true:
 - Parsers use [`Zod`](https://github.com/colinhacks/zod) validation.
 - Query `input` parsers extend `ZodObject<{ [string]: ZodString }>`.
 - Mutation `input` parsers extend `ZodObject<{ [string]: ZodType }>`.
-- `meta.openapi.enabled` is set to `true`.
-- `meta.openapi.method` is `GET` or `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
-- `meta.openapi.path` is a string starting with `/`.
-- `meta.openapi.path` parameters are specified using `{}`.
-- `meta.openapi.path` parameters are present in `input` parser as `ZodString`
+- `meta.openapi` object has the following keys.
+  - `.enabled` is set to `true`.
+  - `.method` is `GET` or `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
+  - `.path` is a string starting with `/`.
+  - `.path` parameters exist in `input` parser as `ZodString`
 
-Note that data [`transformers`](https://trpc.io/docs/data-transformers) are ignored by `trpc-openapi`.
+Note:
+
+- Data [`transformers`](https://trpc.io/docs/data-transformers) are ignored.
+- Trailing slashes are ignored.
 
 ## Authorization
 

--- a/examples/with-express/README.md
+++ b/examples/with-express/README.md
@@ -6,3 +6,7 @@
 npm install
 npm run dev
 ```
+
+### Learn more
+
+[**`trpc-openapi`**](README.md)

--- a/examples/with-express/README.md
+++ b/examples/with-express/README.md
@@ -1,4 +1,4 @@
-# trpc-openapi (with-express)
+# [**`trpc-openapi`**](../../README.md) (with-express)
 
 ### Getting started
 
@@ -6,7 +6,3 @@
 npm install
 npm run dev
 ```
-
-### Learn more
-
-[**`trpc-openapi`**](README.md)

--- a/examples/with-express/package.json
+++ b/examples/with-express/package.json
@@ -10,23 +10,23 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@trpc/server": "^9.23.4",
+    "@trpc/server": "^9.23.0",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "jsonwebtoken": "^8.5.1",
     "swagger-ui-express": "^4.4.0",
     "uuid": "^8.3.2",
-    "zod": "^3.16.0"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/jsonwebtoken": "^8.5.8",
-    "@types/node": "^17.0.34",
+    "@types/node": "^17.0.38",
     "@types/swagger-ui-express": "^4.1.3",
     "@types/uuid": "^8.3.4",
-    "ts-node": "^10.7.0",
-    "ts-node-dev": "^1.1.8",
-    "typescript": "^4.6.4"
+    "ts-node": "^10.8.0",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^4.7.2"
   }
 }

--- a/examples/with-express/src/router.ts
+++ b/examples/with-express/src/router.ts
@@ -131,12 +131,12 @@ const authRouter = createRouter()
     },
   });
 
-const userRouter = createRouter().query('getUser', {
+const userRouter = createRouter().query('getUserById', {
   meta: {
     openapi: {
       enabled: true,
       method: 'GET',
-      path: '/user',
+      path: '/user/{id}',
       tags: ['users'],
       summary: 'Read a user by id',
     },
@@ -166,12 +166,12 @@ const userRouter = createRouter().query('getUser', {
 });
 
 const postRouter = createRouter()
-  .query('getPost', {
+  .query('getPostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         summary: 'Read a post by id',
       },
@@ -199,17 +199,19 @@ const postRouter = createRouter()
       return { post };
     },
   })
-  .query('getAllPosts', {
+  .query('getPosts', {
     meta: {
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/posts',
+        path: '/post',
         tags: ['posts'],
         summary: 'Read all posts',
       },
     },
-    input: z.object({}),
+    input: z.object({
+      userId: z.string().uuid().optional(),
+    }),
     output: z.object({
       posts: z.array(
         z.object({
@@ -219,8 +221,16 @@ const postRouter = createRouter()
         }),
       ),
     }),
-    resolve: () => {
-      return { posts: database.posts };
+    resolve: ({ input }) => {
+      let posts: Post[] = database.posts;
+
+      if (input.userId) {
+        posts = posts.filter((post) => {
+          return post.userId === input.userId;
+        });
+      }
+
+      return { posts };
     },
   });
 
@@ -237,7 +247,7 @@ const postProtectedRouter = createProtectedRouter()
       },
     },
     input: z.object({
-      content: z.string().min(1),
+      content: z.string().min(1).max(140),
     }),
     output: z.object({
       post: z.object({
@@ -258,12 +268,12 @@ const postProtectedRouter = createProtectedRouter()
       return { post };
     },
   })
-  .mutation('updatePost', {
+  .mutation('updatePostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'PUT',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Update an existing post',
@@ -301,12 +311,12 @@ const postProtectedRouter = createProtectedRouter()
       return { post };
     },
   })
-  .query('deletePost', {
+  .query('deletePostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'DELETE',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Delete a post',

--- a/examples/with-express/src/router.ts
+++ b/examples/with-express/src/router.ts
@@ -62,7 +62,7 @@ const authRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/register',
+        path: '/auth/register',
         tags: ['auth'],
         summary: 'Register as a new user',
       },
@@ -97,7 +97,7 @@ const authRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/login',
+        path: '/auth/login',
         tags: ['auth'],
         summary: 'Login as an existing user',
       },
@@ -136,7 +136,7 @@ const userRouter = createRouter().query('getUserById', {
     openapi: {
       enabled: true,
       method: 'GET',
-      path: '/user/{id}',
+      path: '/users/{id}',
       tags: ['users'],
       summary: 'Read a user by id',
     },
@@ -171,7 +171,7 @@ const postRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         summary: 'Read a post by id',
       },
@@ -204,7 +204,7 @@ const postRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post',
+        path: '/posts',
         tags: ['posts'],
         summary: 'Read all posts',
       },
@@ -240,7 +240,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/post',
+        path: '/posts',
         tags: ['posts'],
         protect: true,
         summary: 'Create a new post',
@@ -273,7 +273,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'PUT',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Update an existing post',
@@ -316,7 +316,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'DELETE',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Delete a post',

--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -6,3 +6,7 @@
 npm install
 npm run dev
 ```
+
+### Learn more
+
+[**`trpc-openapi`**](README.md)

--- a/examples/with-nextjs/README.md
+++ b/examples/with-nextjs/README.md
@@ -1,4 +1,4 @@
-# trpc-openapi (with-nextjs)
+# [**`trpc-openapi`**](../../README.md) (with-nextjs)
 
 ### Getting started
 
@@ -6,7 +6,3 @@
 npm install
 npm run dev
 ```
-
-### Learn more
-
-[**`trpc-openapi`**](README.md)

--- a/examples/with-nextjs/package.json
+++ b/examples/with-nextjs/package.json
@@ -9,24 +9,24 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@trpc/server": "^9.23.4",
+    "@trpc/server": "^9.23.0",
     "jsonwebtoken": "^8.5.1",
     "next": "12.1.6",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "swagger-ui-react": "^4.11.1",
     "uuid": "^8.3.2",
-    "zod": "^3.16.0"
+    "zod": "^3.0.0"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.8",
-    "@types/node": "17.0.34",
-    "@types/react": "18.0.9",
-    "@types/react-dom": "18.0.4",
+    "@types/node": "17.0.38",
+    "@types/react": "18.0.10",
+    "@types/react-dom": "18.0.5",
     "@types/swagger-ui-react": "^4.11.0",
     "@types/uuid": "^8.3.4",
-    "eslint": "8.15.0",
+    "eslint": "8.16.0",
     "eslint-config-next": "12.1.6",
-    "typescript": "4.6.4"
+    "typescript": "4.7.2"
   }
 }

--- a/examples/with-nextjs/src/server/router.ts
+++ b/examples/with-nextjs/src/server/router.ts
@@ -59,7 +59,7 @@ const authRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/register',
+        path: '/auth/register',
         tags: ['auth'],
         summary: 'Register as a new user',
       },
@@ -94,7 +94,7 @@ const authRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/login',
+        path: '/auth/login',
         tags: ['auth'],
         summary: 'Login as an existing user',
       },
@@ -133,7 +133,7 @@ const userRouter = createRouter().query('getUserById', {
     openapi: {
       enabled: true,
       method: 'GET',
-      path: '/user/{id}',
+      path: '/users/{id}',
       tags: ['users'],
       summary: 'Read a user by id',
     },
@@ -168,7 +168,7 @@ const postRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         summary: 'Read a post by id',
       },
@@ -201,7 +201,7 @@ const postRouter = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post',
+        path: '/posts',
         tags: ['posts'],
         summary: 'Read all posts',
       },
@@ -237,7 +237,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'POST',
-        path: '/post',
+        path: '/posts',
         tags: ['posts'],
         protect: true,
         summary: 'Create a new post',
@@ -270,7 +270,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'PUT',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Update an existing post',
@@ -313,7 +313,7 @@ const postProtectedRouter = createProtectedRouter()
       openapi: {
         enabled: true,
         method: 'DELETE',
-        path: '/post/{id}',
+        path: '/posts/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Delete a post',

--- a/examples/with-nextjs/src/server/router.ts
+++ b/examples/with-nextjs/src/server/router.ts
@@ -128,12 +128,12 @@ const authRouter = createRouter()
     },
   });
 
-const userRouter = createRouter().query('getUser', {
+const userRouter = createRouter().query('getUserById', {
   meta: {
     openapi: {
       enabled: true,
       method: 'GET',
-      path: '/user',
+      path: '/user/{id}',
       tags: ['users'],
       summary: 'Read a user by id',
     },
@@ -163,12 +163,12 @@ const userRouter = createRouter().query('getUser', {
 });
 
 const postRouter = createRouter()
-  .query('getPost', {
+  .query('getPostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         summary: 'Read a post by id',
       },
@@ -196,17 +196,19 @@ const postRouter = createRouter()
       return { post };
     },
   })
-  .query('getAllPosts', {
+  .query('getPosts', {
     meta: {
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/posts',
+        path: '/post',
         tags: ['posts'],
         summary: 'Read all posts',
       },
     },
-    input: z.object({}),
+    input: z.object({
+      userId: z.string().uuid().optional(),
+    }),
     output: z.object({
       posts: z.array(
         z.object({
@@ -216,8 +218,16 @@ const postRouter = createRouter()
         }),
       ),
     }),
-    resolve: () => {
-      return { posts: database.posts };
+    resolve: ({ input }) => {
+      let posts: Post[] = database.posts;
+
+      if (input.userId) {
+        posts = posts.filter((post) => {
+          return post.userId === input.userId;
+        });
+      }
+
+      return { posts };
     },
   });
 
@@ -234,7 +244,7 @@ const postProtectedRouter = createProtectedRouter()
       },
     },
     input: z.object({
-      content: z.string().min(1),
+      content: z.string().min(1).max(140),
     }),
     output: z.object({
       post: z.object({
@@ -255,12 +265,12 @@ const postProtectedRouter = createProtectedRouter()
       return { post };
     },
   })
-  .mutation('updatePost', {
+  .mutation('updatePostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'PUT',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Update an existing post',
@@ -298,12 +308,12 @@ const postProtectedRouter = createProtectedRouter()
       return { post };
     },
   })
-  .query('deletePost', {
+  .query('deletePostById', {
     meta: {
       openapi: {
         enabled: true,
         method: 'DELETE',
-        path: '/post',
+        path: '/post/{id}',
         tags: ['posts'],
         protect: true,
         summary: 'Delete a post',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,12 @@
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/express": "^4.17.13",
-        "@types/jest": "^27.5.0",
-        "@types/node": "^17.0.31",
+        "@types/jest": "^27.5.2",
+        "@types/node": "^17.0.38",
         "@types/node-fetch": "^2.6.1",
-        "@types/uuid": "^8.3.4",
-        "@typescript-eslint/eslint-plugin": "^5.23.0",
-        "@typescript-eslint/parser": "^5.23.0",
-        "eslint": "^8.15.0",
+        "@typescript-eslint/eslint-plugin": "^5.27.0",
+        "@typescript-eslint/parser": "^5.27.0",
+        "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -29,20 +28,20 @@
         "express": "^4.18.1",
         "jest": "^28.1.0",
         "next": "^12.1.6",
-        "node-fetch": "^2.6.7",
-        "openapi-schema-validator": "^11.0.0",
+        "node-fetch": "^3.2.4",
+        "openapi-schema-validator": "^11.0.1",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
         "superjson": "^1.9.1",
-        "ts-jest": "^28.0.2",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.4"
+        "ts-jest": "^28.0.3",
+        "ts-node": "^10.8.0",
+        "typescript": "^4.7.2"
       },
       "peerDependencies": {
         "@trpc/server": "^9.23.0",
-        "body-parser": "^1.20.0",
+        "body-parser": "^1.0.0",
         "openapi-types": "^11.0.0",
-        "zod": "^3.17.3",
+        "zod": "^3.0.0",
         "zod-to-json-schema": "^3.17.0"
       }
     },
@@ -50,116 +49,48 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@trpc/server": "^9.23.4",
+        "@trpc/server": "^9.23.0",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "jsonwebtoken": "^8.5.1",
         "swagger-ui-express": "^4.4.0",
         "uuid": "^8.3.2",
-        "zod": "^3.16.0"
+        "zod": "^3.0.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/node": "^17.0.34",
+        "@types/node": "^17.0.38",
         "@types/swagger-ui-express": "^4.1.3",
         "@types/uuid": "^8.3.4",
-        "ts-node": "^10.7.0",
-        "ts-node-dev": "^1.1.8",
-        "typescript": "^4.6.4"
+        "ts-node": "^10.8.0",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^4.7.2"
       }
-    },
-    "examples/with-express/node_modules/@trpc/server": {
-      "version": "9.23.6",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-      "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
     },
     "examples/with-nextjs": {
       "version": "1.0.0",
       "dependencies": {
-        "@trpc/server": "^9.23.4",
+        "@trpc/server": "^9.23.0",
         "jsonwebtoken": "^8.5.1",
         "next": "12.1.6",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "swagger-ui-react": "^4.11.1",
         "uuid": "^8.3.2",
-        "zod": "^3.16.0"
+        "zod": "^3.0.0"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/node": "17.0.34",
-        "@types/react": "18.0.9",
-        "@types/react-dom": "18.0.4",
+        "@types/node": "17.0.38",
+        "@types/react": "18.0.10",
+        "@types/react-dom": "18.0.5",
         "@types/swagger-ui-react": "^4.11.0",
         "@types/uuid": "^8.3.4",
-        "eslint": "8.15.0",
+        "eslint": "8.16.0",
         "eslint-config-next": "12.1.6",
-        "typescript": "4.6.4"
-      }
-    },
-    "examples/with-nextjs/node_modules/@trpc/server": {
-      "version": "9.23.6",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-      "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
-    },
-    "examples/with-nextjs/node_modules/@types/node": {
-      "version": "17.0.34",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-      "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
-      "dev": true
-    },
-    "examples/with-nextjs/node_modules/eslint": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
-      "dev": true,
-      "dependencies": {
-        "@eslint/eslintrc": "^1.2.3",
-        "@humanwhocodes/config-array": "^0.9.2",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.2",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "typescript": "4.7.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1786,10 +1717,9 @@
       }
     },
     "node_modules/@trpc/server": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.0.tgz",
-      "integrity": "sha512-OdbRTC8lVY0TPRfWcUswJpku/AzXdFZ9iLPwqbv2lpnZ0O9WlQdpItr0nNpOckUCswOJAhpUbwQmBpFnYQmpaQ==",
-      "peer": true
+      "version": "9.23.6",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
+      "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -1955,9 +1885,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.1.tgz",
-      "integrity": "sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
@@ -1992,9 +1922,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -2031,9 +1961,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
-      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.10.tgz",
+      "integrity": "sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2041,9 +1971,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.4.tgz",
-      "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz",
+      "integrity": "sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -2139,14 +2069,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
-      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.0.tgz",
+      "integrity": "sha512-DDrIA7GXtmHXr1VCcx9HivA39eprYBIFxbQEHI6NyraRDxCGpxAFiYQAT/1Y0vh1C+o2vfBiy4IuPoXxtTZCAQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/type-utils": "5.26.0",
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/type-utils": "5.27.0",
+        "@typescript-eslint/utils": "5.27.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -2187,14 +2117,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
-      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.0.tgz",
+      "integrity": "sha512-8oGjQF46c52l7fMiPPvX4It3u3V3JipssqDfHQ2hcR0AeR8Zge+OYyKUCm5b70X72N1qXt0qgHenwN6Gc2SXZA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/typescript-estree": "5.27.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2214,13 +2144,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
-      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.0.tgz",
+      "integrity": "sha512-VnykheBQ/sHd1Vt0LJ1JLrMH1GzHO+SzX6VTXuStISIsvRiurue/eRkTqSrG0CexHQgKG8shyJfR4o5VYioB9g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0"
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/visitor-keys": "5.27.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2231,12 +2161,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
-      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz",
+      "integrity": "sha512-vpTvRRchaf628Hb/Xzfek+85o//zEUotr1SmexKvTfs7czXfYjXVT/a5yDbpzLBX1rhbqxjDdr1Gyo0x1Fc64g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/utils": "5.27.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2257,9 +2187,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
-      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.0.tgz",
+      "integrity": "sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2270,13 +2200,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
-      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.0.tgz",
+      "integrity": "sha512-QywPMFvgZ+MHSLRofLI7BDL+UczFFHyj0vF5ibeChDAJgdTV8k4xgEwF0geFhVlPc1p8r70eYewzpo6ps+9LJQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/visitor-keys": "5.27.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2312,15 +2242,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
-      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.0.tgz",
+      "integrity": "sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/typescript-estree": "5.27.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2358,12 +2288,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
-      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz",
+      "integrity": "sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/types": "5.27.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -3259,6 +3189,25 @@
         "node-fetch": "2.6.7"
       }
     },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3288,6 +3237,15 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4348,6 +4306,38 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4470,6 +4460,18 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6813,22 +6815,21 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
+      "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+      "dev": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -8546,15 +8547,15 @@
       "link": true
     },
     "node_modules/ts-jest": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.2.tgz",
-      "integrity": "sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==",
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.3.tgz",
+      "integrity": "sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==",
       "dev": true,
       "dependencies": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^28.0.0",
-        "json5": "2.x",
+        "json5": "^2.2.1",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
         "semver": "7.x",
@@ -8647,20 +8648,20 @@
       }
     },
     "node_modules/ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "bin": {
@@ -8690,51 +8691,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
       }
     },
     "node_modules/tsconfig": {
@@ -8871,9 +8827,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10426,10 +10382,9 @@
       }
     },
     "@trpc/server": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.0.tgz",
-      "integrity": "sha512-OdbRTC8lVY0TPRfWcUswJpku/AzXdFZ9iLPwqbv2lpnZ0O9WlQdpItr0nNpOckUCswOJAhpUbwQmBpFnYQmpaQ==",
-      "peer": true
+      "version": "9.23.6",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
+      "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",
@@ -10595,9 +10550,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.1.tgz",
-      "integrity": "sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==",
+      "version": "27.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+      "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
       "dev": true,
       "requires": {
         "jest-matcher-utils": "^27.0.0",
@@ -10632,9 +10587,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+      "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -10671,9 +10626,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
-      "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.10.tgz",
+      "integrity": "sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -10681,9 +10636,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.4.tgz",
-      "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz",
+      "integrity": "sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -10779,14 +10734,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
-      "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.0.tgz",
+      "integrity": "sha512-DDrIA7GXtmHXr1VCcx9HivA39eprYBIFxbQEHI6NyraRDxCGpxAFiYQAT/1Y0vh1C+o2vfBiy4IuPoXxtTZCAQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/type-utils": "5.26.0",
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/type-utils": "5.27.0",
+        "@typescript-eslint/utils": "5.27.0",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -10807,52 +10762,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
-      "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.0.tgz",
+      "integrity": "sha512-8oGjQF46c52l7fMiPPvX4It3u3V3JipssqDfHQ2hcR0AeR8Zge+OYyKUCm5b70X72N1qXt0qgHenwN6Gc2SXZA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/typescript-estree": "5.27.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
-      "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.0.tgz",
+      "integrity": "sha512-VnykheBQ/sHd1Vt0LJ1JLrMH1GzHO+SzX6VTXuStISIsvRiurue/eRkTqSrG0CexHQgKG8shyJfR4o5VYioB9g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0"
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/visitor-keys": "5.27.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
-      "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz",
+      "integrity": "sha512-vpTvRRchaf628Hb/Xzfek+85o//zEUotr1SmexKvTfs7czXfYjXVT/a5yDbpzLBX1rhbqxjDdr1Gyo0x1Fc64g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.26.0",
+        "@typescript-eslint/utils": "5.27.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
-      "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.0.tgz",
+      "integrity": "sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
-      "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.0.tgz",
+      "integrity": "sha512-QywPMFvgZ+MHSLRofLI7BDL+UczFFHyj0vF5ibeChDAJgdTV8k4xgEwF0geFhVlPc1p8r70eYewzpo6ps+9LJQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/visitor-keys": "5.26.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/visitor-keys": "5.27.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -10872,15 +10827,15 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
-      "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.0.tgz",
+      "integrity": "sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.26.0",
-        "@typescript-eslint/types": "5.26.0",
-        "@typescript-eslint/typescript-estree": "5.26.0",
+        "@typescript-eslint/scope-manager": "5.27.0",
+        "@typescript-eslint/types": "5.27.0",
+        "@typescript-eslint/typescript-estree": "5.27.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -10904,12 +10859,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
-      "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz",
+      "integrity": "sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.26.0",
+        "@typescript-eslint/types": "5.27.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -11553,6 +11508,16 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -11580,6 +11545,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
       "dev": true
     },
     "debug": {
@@ -12392,6 +12363,24 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "dependencies": {
+        "web-streams-polyfill": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+          "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+          "dev": true
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12492,6 +12481,15 @@
       "requires": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.1"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "requires": {
+        "fetch-blob": "^3.1.2"
       }
     },
     "forwarded": {
@@ -14209,11 +14207,14 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
+      "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+      "dev": true,
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-int64": {
@@ -15491,13 +15492,12 @@
       "requires": {
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@types/express": "^4.17.13",
-        "@types/jest": "^27.5.0",
-        "@types/node": "^17.0.31",
+        "@types/jest": "^27.5.2",
+        "@types/node": "^17.0.38",
         "@types/node-fetch": "^2.6.1",
-        "@types/uuid": "^8.3.4",
-        "@typescript-eslint/eslint-plugin": "^5.23.0",
-        "@typescript-eslint/parser": "^5.23.0",
-        "eslint": "^8.15.0",
+        "@typescript-eslint/eslint-plugin": "^5.27.0",
+        "@typescript-eslint/parser": "^5.27.0",
+        "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -15505,15 +15505,15 @@
         "express": "^4.18.1",
         "jest": "^28.1.0",
         "next": "^12.1.6",
-        "node-fetch": "^2.6.7",
-        "openapi-schema-validator": "^11.0.0",
+        "node-fetch": "^3.2.4",
+        "openapi-schema-validator": "^11.0.1",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
         "superjson": "^1.9.1",
         "trpc-openapi": "file:",
-        "ts-jest": "^28.0.2",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.4",
+        "ts-jest": "^28.0.3",
+        "ts-node": "^10.8.0",
+        "typescript": "^4.7.2",
         "with-express": "file:examples/with-express",
         "with-nextjs": "file:examples/with-nextjs"
       },
@@ -16736,10 +16736,9 @@
           }
         },
         "@trpc/server": {
-          "version": "9.23.0",
-          "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.0.tgz",
-          "integrity": "sha512-OdbRTC8lVY0TPRfWcUswJpku/AzXdFZ9iLPwqbv2lpnZ0O9WlQdpItr0nNpOckUCswOJAhpUbwQmBpFnYQmpaQ==",
-          "peer": true
+          "version": "9.23.6",
+          "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
+          "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
         },
         "@tsconfig/node10": {
           "version": "1.0.8",
@@ -16905,9 +16904,9 @@
           }
         },
         "@types/jest": {
-          "version": "27.5.1",
-          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.1.tgz",
-          "integrity": "sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==",
+          "version": "27.5.2",
+          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
+          "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
           "dev": true,
           "requires": {
             "jest-matcher-utils": "^27.0.0",
@@ -16942,9 +16941,9 @@
           "dev": true
         },
         "@types/node": {
-          "version": "17.0.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-          "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
+          "version": "17.0.38",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz",
+          "integrity": "sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==",
           "dev": true
         },
         "@types/node-fetch": {
@@ -16981,9 +16980,9 @@
           "dev": true
         },
         "@types/react": {
-          "version": "18.0.9",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.9.tgz",
-          "integrity": "sha512-9bjbg1hJHUm4De19L1cHiW0Jvx3geel6Qczhjd0qY5VKVE2X5+x77YxAepuCwVh4vrgZJdgEJw48zrhRIeF4Nw==",
+          "version": "18.0.10",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.10.tgz",
+          "integrity": "sha512-dIugadZuIPrRzvIEevIu7A1smqOAjkSMv8qOfwPt9Ve6i6JT/FQcCHyk2qIAxwsQNKZt5/oGR0T4z9h2dXRAkg==",
           "requires": {
             "@types/prop-types": "*",
             "@types/scheduler": "*",
@@ -16991,9 +16990,9 @@
           }
         },
         "@types/react-dom": {
-          "version": "18.0.4",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.4.tgz",
-          "integrity": "sha512-FgTtbqPOCI3dzZPZoC2T/sx3L34qxy99ITWn4eoSA95qPyXDMH0ALoAqUp49ITniiJFsXUVBtalh/KffMpg21Q==",
+          "version": "18.0.5",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz",
+          "integrity": "sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==",
           "dev": true,
           "requires": {
             "@types/react": "*"
@@ -17089,14 +17088,14 @@
           "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.26.0.tgz",
-          "integrity": "sha512-oGCmo0PqnRZZndr+KwvvAUvD3kNE4AfyoGCwOZpoCncSh4MVD06JTE8XQa2u9u+NX5CsyZMBTEc2C72zx38eYA==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.0.tgz",
+          "integrity": "sha512-DDrIA7GXtmHXr1VCcx9HivA39eprYBIFxbQEHI6NyraRDxCGpxAFiYQAT/1Y0vh1C+o2vfBiy4IuPoXxtTZCAQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.26.0",
-            "@typescript-eslint/type-utils": "5.26.0",
-            "@typescript-eslint/utils": "5.26.0",
+            "@typescript-eslint/scope-manager": "5.27.0",
+            "@typescript-eslint/type-utils": "5.27.0",
+            "@typescript-eslint/utils": "5.27.0",
             "debug": "^4.3.4",
             "functional-red-black-tree": "^1.0.1",
             "ignore": "^5.2.0",
@@ -17117,52 +17116,52 @@
           }
         },
         "@typescript-eslint/parser": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.26.0.tgz",
-          "integrity": "sha512-n/IzU87ttzIdnAH5vQ4BBDnLPly7rC5VnjN3m0xBG82HK6rhRxnCb3w/GyWbNDghPd+NktJqB/wl6+YkzZ5T5Q==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.0.tgz",
+          "integrity": "sha512-8oGjQF46c52l7fMiPPvX4It3u3V3JipssqDfHQ2hcR0AeR8Zge+OYyKUCm5b70X72N1qXt0qgHenwN6Gc2SXZA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/scope-manager": "5.26.0",
-            "@typescript-eslint/types": "5.26.0",
-            "@typescript-eslint/typescript-estree": "5.26.0",
+            "@typescript-eslint/scope-manager": "5.27.0",
+            "@typescript-eslint/types": "5.27.0",
+            "@typescript-eslint/typescript-estree": "5.27.0",
             "debug": "^4.3.4"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.26.0.tgz",
-          "integrity": "sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.0.tgz",
+          "integrity": "sha512-VnykheBQ/sHd1Vt0LJ1JLrMH1GzHO+SzX6VTXuStISIsvRiurue/eRkTqSrG0CexHQgKG8shyJfR4o5VYioB9g==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.26.0",
-            "@typescript-eslint/visitor-keys": "5.26.0"
+            "@typescript-eslint/types": "5.27.0",
+            "@typescript-eslint/visitor-keys": "5.27.0"
           }
         },
         "@typescript-eslint/type-utils": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.26.0.tgz",
-          "integrity": "sha512-7ccbUVWGLmcRDSA1+ADkDBl5fP87EJt0fnijsMFTVHXKGduYMgienC/i3QwoVhDADUAPoytgjbZbCOMj4TY55A==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.0.tgz",
+          "integrity": "sha512-vpTvRRchaf628Hb/Xzfek+85o//zEUotr1SmexKvTfs7czXfYjXVT/a5yDbpzLBX1rhbqxjDdr1Gyo0x1Fc64g==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/utils": "5.26.0",
+            "@typescript-eslint/utils": "5.27.0",
             "debug": "^4.3.4",
             "tsutils": "^3.21.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.26.0.tgz",
-          "integrity": "sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.0.tgz",
+          "integrity": "sha512-lY6C7oGm9a/GWhmUDOs3xAVRz4ty/XKlQ2fOLr8GAIryGn0+UBOoJDWyHer3UgrHkenorwvBnphhP+zPmzmw0A==",
           "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.26.0.tgz",
-          "integrity": "sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.0.tgz",
+          "integrity": "sha512-QywPMFvgZ+MHSLRofLI7BDL+UczFFHyj0vF5ibeChDAJgdTV8k4xgEwF0geFhVlPc1p8r70eYewzpo6ps+9LJQ==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.26.0",
-            "@typescript-eslint/visitor-keys": "5.26.0",
+            "@typescript-eslint/types": "5.27.0",
+            "@typescript-eslint/visitor-keys": "5.27.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -17182,15 +17181,15 @@
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.26.0.tgz",
-          "integrity": "sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.0.tgz",
+          "integrity": "sha512-nZvCrkIJppym7cIbP3pOwIkAefXOmfGPnCM0LQfzNaKxJHI6VjI8NC662uoiPlaf5f6ymkTy9C3NQXev2mdXmA==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.26.0",
-            "@typescript-eslint/types": "5.26.0",
-            "@typescript-eslint/typescript-estree": "5.26.0",
+            "@typescript-eslint/scope-manager": "5.27.0",
+            "@typescript-eslint/types": "5.27.0",
+            "@typescript-eslint/typescript-estree": "5.27.0",
             "eslint-scope": "^5.1.1",
             "eslint-utils": "^3.0.0"
           },
@@ -17214,12 +17213,12 @@
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.26.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.26.0.tgz",
-          "integrity": "sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==",
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.0.tgz",
+          "integrity": "sha512-46cYrteA2MrIAjv9ai44OQDUoCZyHeGIc4lsjCUX2WT6r4C+kidz1bNiR4017wHOPUythYeH+Sc7/cFP97KEAA==",
           "dev": true,
           "requires": {
-            "@typescript-eslint/types": "5.26.0",
+            "@typescript-eslint/types": "5.27.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -17863,6 +17862,16 @@
           "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
           "requires": {
             "node-fetch": "2.6.7"
+          },
+          "dependencies": {
+            "node-fetch": {
+              "version": "2.6.7",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+              "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+              "requires": {
+                "whatwg-url": "^5.0.0"
+              }
+            }
           }
         },
         "cross-spawn": {
@@ -17890,6 +17899,12 @@
           "version": "1.0.8",
           "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
           "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+          "dev": true
+        },
+        "data-uri-to-buffer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+          "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
           "dev": true
         },
         "debug": {
@@ -18702,6 +18717,24 @@
             "bser": "2.1.1"
           }
         },
+        "fetch-blob": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
+          "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
+          "dev": true,
+          "requires": {
+            "node-domexception": "^1.0.0",
+            "web-streams-polyfill": "^3.0.3"
+          },
+          "dependencies": {
+            "web-streams-polyfill": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+              "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+              "dev": true
+            }
+          }
+        },
         "file-entry-cache": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -18802,6 +18835,15 @@
           "requires": {
             "node-domexception": "1.0.0",
             "web-streams-polyfill": "4.0.0-beta.1"
+          }
+        },
+        "formdata-polyfill": {
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+          "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+          "dev": true,
+          "requires": {
+            "fetch-blob": "^3.1.2"
           }
         },
         "forwarded": {
@@ -20519,11 +20561,14 @@
           "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
+          "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
+          "dev": true,
           "requires": {
-            "whatwg-url": "^5.0.0"
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
           }
         },
         "node-int64": {
@@ -21797,15 +21842,15 @@
           "dev": true
         },
         "ts-jest": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.2.tgz",
-          "integrity": "sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==",
+          "version": "28.0.3",
+          "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.3.tgz",
+          "integrity": "sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==",
           "dev": true,
           "requires": {
             "bs-logger": "0.x",
             "fast-json-stable-stringify": "2.x",
             "jest-util": "^28.0.0",
-            "json5": "2.x",
+            "json5": "^2.2.1",
             "lodash.memoize": "4.x",
             "make-error": "1.x",
             "semver": "7.x",
@@ -21845,20 +21890,20 @@
           }
         },
         "ts-node-dev": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-          "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+          "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
           "dev": true,
           "requires": {
             "chokidar": "^3.5.1",
             "dynamic-dedupe": "^0.3.0",
-            "minimist": "^1.2.5",
+            "minimist": "^1.2.6",
             "mkdirp": "^1.0.4",
             "resolve": "^1.0.0",
             "rimraf": "^2.6.1",
             "source-map-support": "^0.5.12",
             "tree-kill": "^1.2.2",
-            "ts-node": "^9.0.0",
+            "ts-node": "^10.4.0",
             "tsconfig": "^7.0.0"
           },
           "dependencies": {
@@ -21869,36 +21914,6 @@
               "dev": true,
               "requires": {
                 "glob": "^7.1.3"
-              }
-            },
-            "source-map": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-              "dev": true
-            },
-            "source-map-support": {
-              "version": "0.5.21",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-              "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-              "dev": true,
-              "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
-              }
-            },
-            "ts-node": {
-              "version": "9.1.1",
-              "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-              "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-              "dev": true,
-              "requires": {
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "source-map-support": "^0.5.17",
-                "yn": "3.1.1"
               }
             }
           }
@@ -22010,9 +22025,9 @@
           }
         },
         "typescript": {
-          "version": "4.6.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-          "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+          "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
           "dev": true
         },
         "unbox-primitive": {
@@ -22157,107 +22172,44 @@
         "with-express": {
           "version": "file:examples/with-express",
           "requires": {
-            "@trpc/server": "^9.23.4",
+            "@trpc/server": "^9.23.0",
             "@types/cors": "^2.8.12",
             "@types/express": "^4.17.13",
             "@types/jsonwebtoken": "^8.5.8",
-            "@types/node": "^17.0.34",
+            "@types/node": "^17.0.38",
             "@types/swagger-ui-express": "^4.1.3",
             "@types/uuid": "^8.3.4",
             "cors": "^2.8.5",
             "express": "^4.18.1",
             "jsonwebtoken": "^8.5.1",
             "swagger-ui-express": "^4.4.0",
-            "ts-node": "^10.7.0",
-            "ts-node-dev": "^1.1.8",
-            "typescript": "^4.6.4",
+            "ts-node": "^10.8.0",
+            "ts-node-dev": "^2.0.0",
+            "typescript": "^4.7.2",
             "uuid": "^8.3.2",
-            "zod": "^3.16.0"
-          },
-          "dependencies": {
-            "@trpc/server": {
-              "version": "9.23.6",
-              "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-              "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
-            }
+            "zod": "^3.0.0"
           }
         },
         "with-nextjs": {
           "version": "file:examples/with-nextjs",
           "requires": {
-            "@trpc/server": "^9.23.4",
+            "@trpc/server": "^9.23.0",
             "@types/jsonwebtoken": "^8.5.8",
-            "@types/node": "17.0.34",
-            "@types/react": "18.0.9",
-            "@types/react-dom": "18.0.4",
+            "@types/node": "17.0.38",
+            "@types/react": "18.0.10",
+            "@types/react-dom": "18.0.5",
             "@types/swagger-ui-react": "^4.11.0",
             "@types/uuid": "^8.3.4",
-            "eslint": "8.15.0",
+            "eslint": "8.16.0",
             "eslint-config-next": "12.1.6",
             "jsonwebtoken": "^8.5.1",
             "next": "12.1.6",
             "react": "18.1.0",
             "react-dom": "18.1.0",
             "swagger-ui-react": "^4.11.1",
-            "typescript": "4.6.4",
+            "typescript": "4.7.2",
             "uuid": "^8.3.2",
-            "zod": "^3.16.0"
-          },
-          "dependencies": {
-            "@trpc/server": {
-              "version": "9.23.6",
-              "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-              "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
-            },
-            "@types/node": {
-              "version": "17.0.34",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-              "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
-              "dev": true
-            },
-            "eslint": {
-              "version": "8.15.0",
-              "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-              "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
-              "dev": true,
-              "requires": {
-                "@eslint/eslintrc": "^1.2.3",
-                "@humanwhocodes/config-array": "^0.9.2",
-                "ajv": "^6.10.0",
-                "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
-                "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.1.1",
-                "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.3.0",
-                "espree": "^9.3.2",
-                "esquery": "^1.4.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^6.0.1",
-                "globals": "^13.6.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.0.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "js-yaml": "^4.1.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.1",
-                "regexpp": "^3.2.0",
-                "strip-ansi": "^6.0.1",
-                "strip-json-comments": "^3.1.0",
-                "text-table": "^0.2.0",
-                "v8-compile-cache": "^2.0.3"
-              }
-            }
+            "zod": "^3.0.0"
           }
         },
         "word-wrap": {
@@ -22378,15 +22330,15 @@
       }
     },
     "ts-jest": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.2.tgz",
-      "integrity": "sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==",
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.3.tgz",
+      "integrity": "sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "fast-json-stable-stringify": "2.x",
         "jest-util": "^28.0.0",
-        "json5": "2.x",
+        "json5": "^2.2.1",
         "lodash.memoize": "4.x",
         "make-error": "1.x",
         "semver": "7.x",
@@ -22426,20 +22378,20 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
@@ -22450,36 +22402,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.21",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
-        "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-          "dev": true,
-          "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
           }
         }
       }
@@ -22591,9 +22513,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "unbox-primitive": {
@@ -22738,107 +22660,44 @@
     "with-express": {
       "version": "file:examples/with-express",
       "requires": {
-        "@trpc/server": "^9.23.4",
+        "@trpc/server": "^9.23.0",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/node": "^17.0.34",
+        "@types/node": "^17.0.38",
         "@types/swagger-ui-express": "^4.1.3",
         "@types/uuid": "^8.3.4",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "jsonwebtoken": "^8.5.1",
         "swagger-ui-express": "^4.4.0",
-        "ts-node": "^10.7.0",
-        "ts-node-dev": "^1.1.8",
-        "typescript": "^4.6.4",
+        "ts-node": "^10.8.0",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^4.7.2",
         "uuid": "^8.3.2",
-        "zod": "^3.16.0"
-      },
-      "dependencies": {
-        "@trpc/server": {
-          "version": "9.23.6",
-          "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-          "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
-        }
+        "zod": "^3.0.0"
       }
     },
     "with-nextjs": {
       "version": "file:examples/with-nextjs",
       "requires": {
-        "@trpc/server": "^9.23.4",
+        "@trpc/server": "^9.23.0",
         "@types/jsonwebtoken": "^8.5.8",
-        "@types/node": "17.0.34",
-        "@types/react": "18.0.9",
-        "@types/react-dom": "18.0.4",
+        "@types/node": "17.0.38",
+        "@types/react": "18.0.10",
+        "@types/react-dom": "18.0.5",
         "@types/swagger-ui-react": "^4.11.0",
         "@types/uuid": "^8.3.4",
-        "eslint": "8.15.0",
+        "eslint": "8.16.0",
         "eslint-config-next": "12.1.6",
         "jsonwebtoken": "^8.5.1",
         "next": "12.1.6",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "swagger-ui-react": "^4.11.1",
-        "typescript": "4.6.4",
+        "typescript": "4.7.2",
         "uuid": "^8.3.2",
-        "zod": "^3.16.0"
-      },
-      "dependencies": {
-        "@trpc/server": {
-          "version": "9.23.6",
-          "resolved": "https://registry.npmjs.org/@trpc/server/-/server-9.23.6.tgz",
-          "integrity": "sha512-xdoHjv0Km6kr7fBpu91rN3wURWGazUA7+dRquWywWLUDH3EiERg6n0Lkz/YgxH7n+liu6UkRs1Npjt6oo01+xA=="
-        },
-        "@types/node": {
-          "version": "17.0.34",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.34.tgz",
-          "integrity": "sha512-XImEz7XwTvDBtzlTnm8YvMqGW/ErMWBsKZ+hMTvnDIjGCKxwK5Xpc+c/oQjOauwq8M4OS11hEkpjX8rrI/eEgA==",
-          "dev": true
-        },
-        "eslint": {
-          "version": "8.15.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-          "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
-          "dev": true,
-          "requires": {
-            "@eslint/eslintrc": "^1.2.3",
-            "@humanwhocodes/config-array": "^0.9.2",
-            "ajv": "^6.10.0",
-            "chalk": "^4.0.0",
-            "cross-spawn": "^7.0.2",
-            "debug": "^4.3.2",
-            "doctrine": "^3.0.0",
-            "escape-string-regexp": "^4.0.0",
-            "eslint-scope": "^7.1.1",
-            "eslint-utils": "^3.0.0",
-            "eslint-visitor-keys": "^3.3.0",
-            "espree": "^9.3.2",
-            "esquery": "^1.4.0",
-            "esutils": "^2.0.2",
-            "fast-deep-equal": "^3.1.3",
-            "file-entry-cache": "^6.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "glob-parent": "^6.0.1",
-            "globals": "^13.6.0",
-            "ignore": "^5.2.0",
-            "import-fresh": "^3.0.0",
-            "imurmurhash": "^0.1.4",
-            "is-glob": "^4.0.0",
-            "js-yaml": "^4.1.0",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.4.1",
-            "lodash.merge": "^4.6.2",
-            "minimatch": "^3.1.2",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.9.1",
-            "regexpp": "^3.2.0",
-            "strip-ansi": "^6.0.1",
-            "strip-json-comments": "^3.1.0",
-            "text-table": "^0.2.0",
-            "v8-compile-cache": "^2.0.3"
-          }
-        }
+        "zod": "^3.0.0"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "express": "^4.18.1",
         "jest": "^28.1.0",
         "next": "^12.1.6",
-        "node-fetch": "^3.2.4",
+        "node-fetch": "^2.6.7",
         "openapi-schema-validator": "^11.0.1",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
@@ -3189,25 +3189,6 @@
         "node-fetch": "2.6.7"
       }
     },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3237,15 +3218,6 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4306,38 +4278,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4460,18 +4400,6 @@
       },
       "engines": {
         "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -6815,21 +6743,22 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
-      "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
-      "dev": true,
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -11508,16 +11437,6 @@
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "requires": {
         "node-fetch": "2.6.7"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
       }
     },
     "cross-spawn": {
@@ -11545,12 +11464,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-      "dev": true
-    },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
       "dev": true
     },
     "debug": {
@@ -12363,24 +12276,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "dependencies": {
-        "web-streams-polyfill": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-          "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-          "dev": true
-        }
-      }
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -12481,15 +12376,6 @@
       "requires": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.1"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "forwarded": {
@@ -14207,14 +14093,11 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
-      "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
-      "dev": true,
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       }
     },
     "node-int64": {
@@ -15505,7 +15388,7 @@
         "express": "^4.18.1",
         "jest": "^28.1.0",
         "next": "^12.1.6",
-        "node-fetch": "^3.2.4",
+        "node-fetch": "2",
         "openapi-schema-validator": "^11.0.1",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
@@ -17862,16 +17745,6 @@
           "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
           "requires": {
             "node-fetch": "2.6.7"
-          },
-          "dependencies": {
-            "node-fetch": {
-              "version": "2.6.7",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-              "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-              "requires": {
-                "whatwg-url": "^5.0.0"
-              }
-            }
           }
         },
         "cross-spawn": {
@@ -17899,12 +17772,6 @@
           "version": "1.0.8",
           "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
           "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-          "dev": true
-        },
-        "data-uri-to-buffer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-          "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
           "dev": true
         },
         "debug": {
@@ -18717,24 +18584,6 @@
             "bser": "2.1.1"
           }
         },
-        "fetch-blob": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-          "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-          "dev": true,
-          "requires": {
-            "node-domexception": "^1.0.0",
-            "web-streams-polyfill": "^3.0.3"
-          },
-          "dependencies": {
-            "web-streams-polyfill": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-              "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-              "dev": true
-            }
-          }
-        },
         "file-entry-cache": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -18835,15 +18684,6 @@
           "requires": {
             "node-domexception": "1.0.0",
             "web-streams-polyfill": "4.0.0-beta.1"
-          }
-        },
-        "formdata-polyfill": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-          "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-          "dev": true,
-          "requires": {
-            "fetch-blob": "^3.1.2"
           }
         },
         "forwarded": {
@@ -20561,14 +20401,11 @@
           "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
         },
         "node-fetch": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.4.tgz",
-          "integrity": "sha512-WvYJRN7mMyOLurFR2YpysQGuwYrJN+qrrpHjJDuKMcSPdfFccRUla/kng2mz6HWSBxJcqPbvatS6Gb4RhOzCJw==",
-          "dev": true,
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
           "requires": {
-            "data-uri-to-buffer": "^4.0.0",
-            "fetch-blob": "^3.1.4",
-            "formdata-polyfill": "^4.0.10"
+            "whatwg-url": "^5.0.0"
           }
         },
         "node-int64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15388,7 +15388,7 @@
         "express": "^4.18.1",
         "jest": "^28.1.0",
         "next": "^12.1.6",
-        "node-fetch": "2",
+        "node-fetch": "^2.6.7",
         "openapi-schema-validator": "^11.0.1",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -26,21 +26,20 @@
   },
   "peerDependencies": {
     "@trpc/server": "^9.23.0",
-    "body-parser": "^1.20.0",
+    "body-parser": "^1.0.0",
     "openapi-types": "^11.0.0",
-    "zod": "^3.17.3",
+    "zod": "^3.0.0",
     "zod-to-json-schema": "^3.17.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/express": "^4.17.13",
-    "@types/jest": "^27.5.0",
-    "@types/node": "^17.0.31",
+    "@types/jest": "^27.5.2",
+    "@types/node": "^17.0.38",
     "@types/node-fetch": "^2.6.1",
-    "@types/uuid": "^8.3.4",
-    "@typescript-eslint/eslint-plugin": "^5.23.0",
-    "@typescript-eslint/parser": "^5.23.0",
-    "eslint": "^8.15.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.0",
+    "@typescript-eslint/parser": "^5.27.0",
+    "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -48,13 +47,13 @@
     "express": "^4.18.1",
     "jest": "^28.1.0",
     "next": "^12.1.6",
-    "node-fetch": "^2.6.7",
-    "openapi-schema-validator": "^11.0.0",
+    "node-fetch": "^3.2.4",
+    "openapi-schema-validator": "^11.0.1",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "superjson": "^1.9.1",
-    "ts-jest": "^28.0.2",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.6.4"
+    "ts-jest": "^28.0.3",
+    "ts-node": "^10.8.0",
+    "typescript": "^4.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": "^4.18.1",
     "jest": "^28.1.0",
     "next": "^12.1.6",
-    "node-fetch": "^3.2.4",
+    "node-fetch": "^2.6.7",
     "openapi-schema-validator": "^11.0.1",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",

--- a/src/adapters/next.ts
+++ b/src/adapters/next.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { OpenApiErrorResponse, OpenApiRouter } from '../types';
-import { getPath } from '../utils';
+import { normalizePath } from '../utils';
 import {
   CreateOpenApiNodeHttpHandlerOptions,
   createOpenApiNodeHttpHandler,
@@ -54,8 +54,7 @@ export const createOpenApiNextHandler = <TRouter extends OpenApiRouter>(
       return;
     }
 
-    const { path } = getPath(pathname);
-    req.url = path;
+    req.url = normalizePath(pathname);
     return openApiHttpHandler(req, res);
   };
 };

--- a/src/adapters/next.ts
+++ b/src/adapters/next.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 import { OpenApiErrorResponse, OpenApiRouter } from '../types';
-import { removeLeadingTrailingSlash } from '../utils';
+import { getPath } from '../utils';
 import {
   CreateOpenApiNodeHttpHandlerOptions,
   createOpenApiNodeHttpHandler,
@@ -19,14 +19,14 @@ export const createOpenApiNextHandler = <TRouter extends OpenApiRouter>(
   const openApiHttpHandler = createOpenApiNodeHttpHandler(opts);
 
   return async (req: NextApiRequest, res: NextApiResponse) => {
-    let path: string | null = null;
+    let pathname: string | null = null;
     if (typeof req.query.trpc === 'string') {
-      path = req.query.trpc;
+      pathname = req.query.trpc;
     } else if (Array.isArray(req.query.trpc)) {
-      path = req.query.trpc.join('/');
+      pathname = req.query.trpc.join('/');
     }
 
-    if (path === null) {
+    if (pathname === null) {
       const error = new TRPCError({
         message: 'Query "trpc" not found - is the file named `[trpc]`.ts or `[...trpc].ts`?',
         code: 'INTERNAL_SERVER_ERROR',
@@ -54,7 +54,8 @@ export const createOpenApiNextHandler = <TRouter extends OpenApiRouter>(
       return;
     }
 
-    req.url = `/${removeLeadingTrailingSlash(path)}`;
+    const { path } = getPath(pathname);
+    req.url = path;
     return openApiHttpHandler(req, res);
   };
 };

--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -13,7 +13,7 @@ import {
   OpenApiRouter,
   OpenApiSuccessResponse,
 } from '../../types';
-import { removeLeadingTrailingSlash } from '../../utils';
+import { getPath } from '../../utils';
 import { TRPC_ERROR_CODE_HTTP_STATUS, getErrorFromUnknown } from './errors';
 import { getBody, getQuery } from './input';
 import { getProcedures } from './procedures';
@@ -66,7 +66,7 @@ export const createOpenApiNodeHttpHandler = <
     const method = req.method!;
     const reqUrl = req.url!;
     const url = new URL(reqUrl.startsWith('/') ? `http://127.0.0.1${reqUrl}` : reqUrl);
-    const path = `/${removeLeadingTrailingSlash(url.pathname)}`;
+    const { path } = getPath(url.pathname);
     const procedure = procedures[method]?.[path];
     let input: any;
     let ctx: any;

--- a/src/adapters/node-http/input.ts
+++ b/src/adapters/node-http/input.ts
@@ -17,7 +17,10 @@ export const getBody = async (req: NodeHTTPRequest, maxBodySize?: number): Promi
     return req.body;
   }
   await new Promise<void>((resolve, reject) => {
-    bodyParser.json({ strict: false, limit: maxBodySize ?? 102400 })(req, {} as any, (error) => {
+    bodyParser.json({
+      strict: true,
+      limit: maxBodySize ?? 102400,
+    })(req, {} as any, (error) => {
       if (error instanceof Error) {
         if (error.name === 'PayloadTooLargeError') {
           reject(

--- a/src/adapters/node-http/procedures.ts
+++ b/src/adapters/node-http/procedures.ts
@@ -1,46 +1,71 @@
 import { OpenApiRouter } from '../../types';
-import { getPath } from '../../utils';
+import { getPathRegExp, normalizePath } from '../../utils';
 
 type Procedure = { type: 'query' | 'mutation'; path: string };
 
-export const getProcedures = (appRouter: OpenApiRouter) => {
-  const procedures: Record<string, Record<string, Procedure>> = {};
+const getMethodPathProcedureMap = (appRouter: OpenApiRouter) => {
+  const map = new Map<string, Map<RegExp, Procedure>>();
 
   const { queries, mutations } = appRouter._def;
 
   for (const queryPath of Object.keys(queries)) {
     const query = queries[queryPath]!;
-    const { openapi } = query.meta || {};
+    const { openapi } = query.meta ?? {};
     if (!openapi?.enabled) {
       continue;
     }
     const { method } = openapi;
-    if (!procedures[method]) {
-      procedures[method] = {};
+    if (!map.has(method)) {
+      map.set(method, new Map());
     }
-    const { path } = getPath(openapi.path);
-    procedures[method]![path] = {
+    const path = normalizePath(openapi.path);
+    const pathRegExp = getPathRegExp(path);
+    map.get(method)!.set(pathRegExp, {
       type: 'query',
       path: queryPath,
-    };
+    });
   }
 
   for (const mutationPath of Object.keys(mutations)) {
-    const query = mutations[mutationPath]!;
-    const { openapi } = query.meta || {};
+    const mutation = mutations[mutationPath]!;
+    const { openapi } = mutation.meta ?? {};
     if (!openapi?.enabled) {
       continue;
     }
     const { method } = openapi;
-    if (!procedures[method]) {
-      procedures[method] = {};
+    if (!map.has(method)) {
+      map.set(method, new Map());
     }
-    const { path } = getPath(openapi.path);
-    procedures[method]![path] = {
+    const path = normalizePath(openapi.path);
+    const pathRegExp = getPathRegExp(path);
+    map.get(method)!.set(pathRegExp, {
       type: 'mutation',
       path: mutationPath,
-    };
+    });
   }
 
-  return procedures;
+  return map;
+};
+
+export const createMatchProcedureFn = (router: OpenApiRouter) => {
+  const methodPathProcedureMap = getMethodPathProcedureMap(router);
+
+  return (method: string, path: string) => {
+    const pathProcedureMap = methodPathProcedureMap.get(method);
+    if (!pathProcedureMap) {
+      return undefined;
+    }
+
+    const matchingRegExp = Array.from(pathProcedureMap.keys()).find((regExp) => {
+      return regExp.test(path);
+    });
+    if (!matchingRegExp) {
+      return undefined;
+    }
+
+    const procedure = pathProcedureMap.get(matchingRegExp)!;
+    const pathInput = matchingRegExp.exec(path)?.groups ?? {};
+
+    return { procedure, pathInput };
+  };
 };

--- a/src/adapters/node-http/procedures.ts
+++ b/src/adapters/node-http/procedures.ts
@@ -1,5 +1,5 @@
 import { OpenApiRouter } from '../../types';
-import { removeLeadingTrailingSlash } from '../../utils';
+import { getPath } from '../../utils';
 
 type Procedure = { type: 'query' | 'mutation'; path: string };
 
@@ -18,7 +18,7 @@ export const getProcedures = (appRouter: OpenApiRouter) => {
     if (!procedures[method]) {
       procedures[method] = {};
     }
-    const path = `/${removeLeadingTrailingSlash(openapi.path)}`;
+    const { path } = getPath(openapi.path);
     procedures[method]![path] = {
       type: 'query',
       path: queryPath,
@@ -35,7 +35,7 @@ export const getProcedures = (appRouter: OpenApiRouter) => {
     if (!procedures[method]) {
       procedures[method] = {};
     }
-    const path = `/${removeLeadingTrailingSlash(openapi.path)}`;
+    const { path } = getPath(openapi.path);
     procedures[method]![path] = {
       type: 'mutation',
       path: mutationPath,

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -15,7 +15,7 @@ export type GenerateOpenApiDocumentOptions = {
 };
 
 export const generateOpenApiDocument = (
-  appRouter: OpenApiRouter<any>,
+  appRouter: OpenApiRouter,
   opts: GenerateOpenApiDocumentOptions,
 ): OpenAPIV3.Document => {
   return {

--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -1,8 +1,9 @@
 import { TRPCError } from '@trpc/server';
 import { OpenAPIV3 } from 'openapi-types';
+import { z } from 'zod';
 
 import { OpenApiRouter } from '../types';
-import { getInputOutputParsers, removeLeadingTrailingSlash } from '../utils';
+import { getInputOutputParsers, getPath } from '../utils';
 import { getParameterObjects, getRequestBodyObject, getResponsesObject } from './schema';
 
 export const getOpenApiPathsObject = (
@@ -27,7 +28,7 @@ export const getOpenApiPathsObject = (
         });
       }
 
-      const path = `/${removeLeadingTrailingSlash(openapi.path)}`;
+      const { path, pathParameters } = getPath(openapi.path);
       const httpMethod = OpenAPIV3.HttpMethods[method];
       if (pathsObject[path]?.[httpMethod]) {
         throw new TRPCError({
@@ -44,7 +45,7 @@ export const getOpenApiPathsObject = (
           summary,
           tags,
           security: protect ? [{ Authorization: [] }] : undefined,
-          parameters: getParameterObjects(inputParser),
+          parameters: getParameterObjects(inputParser, pathParameters, 'all'),
           responses: getResponsesObject(outputParser),
         },
       };
@@ -71,7 +72,7 @@ export const getOpenApiPathsObject = (
         });
       }
 
-      const path = `/${removeLeadingTrailingSlash(openapi.path)}`;
+      const { path, pathParameters } = getPath(openapi.path);
       const httpMethod = OpenAPIV3.HttpMethods[method];
       if (pathsObject[path]?.[httpMethod]) {
         throw new TRPCError({
@@ -89,6 +90,7 @@ export const getOpenApiPathsObject = (
           tags,
           security: protect ? [{ Authorization: [] }] : undefined,
           requestBody: getRequestBodyObject(inputParser),
+          parameters: getParameterObjects(inputParser, pathParameters, 'path'),
           responses: getResponsesObject(outputParser),
         },
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,18 +1,12 @@
-// eslint-disable-next-line import/no-unresolved
-import { Procedure } from '@trpc/server/dist/declarations/src/internals/procedure';
-
-export const getPath = (raw: string) => {
-  const path = `/${raw.replace(/^\/|\/$/g, '')}`;
-  const pathParameters = Array.from(path.matchAll(/\{(\w+)\}/g)).map((matchArray) => {
-    return matchArray[1]!;
-  });
-  return { path, pathParameters };
+export const normalizePath = (path: string) => {
+  return `/${path.replace(/^\/|\/$/g, '')}`;
 };
 
-// `inputParser` & `outputParser` are private so this is a hack to access it
-export const getInputOutputParsers = (procedure: Procedure<any, any, any, any, any, any, any>) => {
-  return procedure as unknown as {
-    inputParser: typeof procedure['inputParser'];
-    outputParser: typeof procedure['outputParser'];
-  };
+export const getPathParameters = (path: string) => {
+  return Array.from(path.matchAll(/\{(.+?)\}/g)).map(([_, key]) => key!);
+};
+
+export const getPathRegExp = (path: string) => {
+  const groupedExp = path.replace(/\{(.+?)\}/g, (_, key: string) => `(?<${key}>[^/]+)`);
+  return new RegExp(`^${groupedExp}$`, 'i');
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,12 @@
 // eslint-disable-next-line import/no-unresolved
 import { Procedure } from '@trpc/server/dist/declarations/src/internals/procedure';
 
-export const removeLeadingTrailingSlash = (path: string) => {
-  return path.replace(/^\/|\/$/g, '');
+export const getPath = (raw: string) => {
+  const path = `/${raw.replace(/^\/|\/$/g, '')}`;
+  const pathParameters = Array.from(path.matchAll(/\{(\w+)\}/g)).map((matchArray) => {
+    return matchArray[1]!;
+  });
+  return { path, pathParameters };
 };
 
 // `inputParser` & `outputParser` are private so this is a hack to access it

--- a/test/adapters/next.test.ts
+++ b/test/adapters/next.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import * as trpc from '@trpc/server';
 import { NextApiRequest, NextApiResponse } from 'next';
-import fetch from 'node-fetch';
 import { z } from 'zod';
 
 import {
@@ -9,7 +8,6 @@ import {
   OpenApiMeta,
   OpenApiResponse,
   OpenApiRouter,
-  OpenApiSuccessResponse,
   createOpenApiNextHandler,
 } from '../../src';
 
@@ -83,9 +81,9 @@ describe('next adapter', () => {
         })
         .mutation('sayHello', {
           meta: { openapi: { enabled: true, method: 'POST', path: '/say-hello' } },
-          input: z.string(),
+          input: z.object({ name: z.string() }),
           output: z.object({ greeting: z.string() }),
-          resolve: ({ input }) => ({ greeting: `Hello ${input}!` }),
+          resolve: ({ input }) => ({ greeting: `Hello ${input.name}!` }),
         })
         .query('sayHelloSplit', {
           meta: { openapi: { enabled: true, method: 'GET', path: '/say/hello' } },
@@ -117,7 +115,7 @@ describe('next adapter', () => {
       const res = await openApiNextHandlerCaller({
         method: 'POST',
         query: { trpc: 'say-hello' },
-        body: 'James',
+        body: { name: 'James' },
       });
 
       expect(res.statusCode).toBe(200);

--- a/test/adapters/standalone.test.ts
+++ b/test/adapters/standalone.test.ts
@@ -15,6 +15,10 @@ import {
   createOpenApiHttpHandler,
 } from '../../src';
 
+// TODO: test for case sensitivity
+// TODO: test for path parameters
+// TODO: test for duplicate paths (using getPathRegExp)
+
 const createContextMock = jest.fn();
 const responseMetaMock = jest.fn();
 const onErrorMock = jest.fn();
@@ -650,7 +654,7 @@ describe('standalone adapter', () => {
     close();
   });
 
-  test.only('with multiple input query string params', async () => {
+  test('with multiple input query string params', async () => {
     const { url, close } = createHttpServerWithRouter({
       router: trpc.router<any, OpenApiMeta>().query('sayHello', {
         meta: { openapi: { enabled: true, method: 'GET', path: '/say-hello' } },

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -485,6 +485,7 @@ describe('generator', () => {
         "paths": Object {
           "/users": Object {
             "delete": Object {
+              "description": undefined,
               "parameters": Array [
                 Object {
                   "description": undefined,
@@ -528,6 +529,7 @@ describe('generator', () => {
               "tags": undefined,
             },
             "get": Object {
+              "description": undefined,
               "parameters": Array [
                 Object {
                   "description": undefined,
@@ -588,6 +590,7 @@ describe('generator', () => {
               "tags": undefined,
             },
             "patch": Object {
+              "description": undefined,
               "parameters": Array [],
               "requestBody": Object {
                 "content": Object {
@@ -660,6 +663,7 @@ describe('generator', () => {
               "tags": undefined,
             },
             "post": Object {
+              "description": undefined,
               "parameters": Array [],
               "requestBody": Object {
                 "content": Object {
@@ -972,15 +976,16 @@ describe('generator', () => {
     `);
   });
 
-  test('with summary & tags', () => {
+  test('with summary, description & tags', () => {
     const appRouter = trpc.router<any, OpenApiMeta>().query('all.metadata', {
       meta: {
         openapi: {
           enabled: true,
           path: '/metadata/all',
           method: 'GET',
-          summary: 'Some summary',
-          tags: ['some-tag'],
+          summary: 'Short summary',
+          description: 'Verbose description',
+          tags: ['tag'],
         },
       },
       input: z.object({ name: z.string() }),
@@ -995,8 +1000,9 @@ describe('generator', () => {
     });
 
     expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-    expect(openApiDocument.paths['/metadata/all']!.get!.summary).toBe('Some summary');
-    expect(openApiDocument.paths['/metadata/all']!.get!.tags).toEqual(['some-tag']);
+    expect(openApiDocument.paths['/metadata/all']!.get!.summary).toBe('Short summary');
+    expect(openApiDocument.paths['/metadata/all']!.get!.description).toBe('Verbose description');
+    expect(openApiDocument.paths['/metadata/all']!.get!.tags).toEqual(['tag']);
   });
 
   test('with security', () => {
@@ -1068,6 +1074,7 @@ describe('generator', () => {
     expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
     expect(openApiDocument.paths['/user']!.post!).toMatchInlineSnapshot(`
       Object {
+        "description": undefined,
         "parameters": Array [],
         "requestBody": Object {
           "content": Object {
@@ -1151,6 +1158,7 @@ describe('generator', () => {
     `);
     expect(openApiDocument.paths['/user']!.get!).toMatchInlineSnapshot(`
       Object {
+        "description": undefined,
         "parameters": Array [
           Object {
             "description": "User ID",

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -393,7 +393,7 @@ describe('generator', () => {
         meta: { openapi: { enabled: true, path: '/users', method: 'PATCH' } },
         input: z.object({ id: z.string(), name: z.string().optional() }),
         output: z.object({ id: z.string(), name: z.string() }),
-        resolve: ({ input }) => ({ id: input.id, name: input.name || 'name' }),
+        resolve: ({ input }) => ({ id: input.id, name: input.name ?? 'name' }),
       })
       .query('deleteUser', {
         meta: { openapi: { enabled: true, path: '/users', method: 'DELETE' } },


### PR DESCRIPTION
Closes https://github.com/jlalmes/trpc-openapi/issues/2.

## Support OpenAPI `path` parameters

Enables you to specify a variable in the URL path & put this value into `input` for a procedure. 
* A parameter is identified when surrounded with `{}` e.g. `/user/{userId}`
* If a parameter is found in the `meta.openapi.path` then it must exist in the `input` parser as `ZodString`.

### OpenAPI Spec

https://swagger.io/docs/specification/describing-parameters/#path-parameters

### Breaking change

Mutation `input` must extend `ZodObject({ [string]: ZodType })` schema.

### Usage

```ts
trpc.router()
  .query('getUserById', {
    meta: { openapi: { enabled: true, method: 'GET', path: '/user/{userId}' } },
    input: z.object({ // validated as ZodObject({ [string]: ZodString })
      userId: z.string(), // `userId` is required in schema because it is used in path
      teamId: z.string(),
    }),
    output: ...,
    resolve: ...,
  })
  .mutation('updateUserById', {
    meta: { openapi: { enabled: true, method: 'PUT', path: '/user/{userId}' } },
    input: z.object({ // validated as ZodObject({ [string]: ZodType })
      userId: z.string(), // `userId` is required in schema & validated as ZodString
      details: z.object({
        name: z.string(),
      }),
    }),
    output: ...,
    resolve: ...,
  })
```
