### PR TITLE
Fix: Yarn not installing `peerDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,18 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 
 ## Requirements
 
-For every OpenAPI enabled procedure the following _must_ be true:
+Peer dependencies:
 
-- [`tRPC`](https://github.com/trpc/trpc) version 9 (`@trpc/server@^9.23.0`) is installed.
-- Both `input` and `output` parsers are present.
-- Parsers use [`Zod`](https://github.com/colinhacks/zod) validation.
-- Query `input` parsers are `ZodObject<{ [string]: ZodString }>` or `ZodVoid`.
-- Mutation `input` parsers are `ZodObject<{ [string]: ZodAnyType }>` or `ZodVoid`.
+- [`tRPC`](https://github.com/trpc/trpc) version 9 (`@trpc/server@^9.23.0`) must be installed.
+- [`Zod`](https://github.com/colinhacks/zod) version 3 (`zod@^3.0.0`) must be installed.
+
+For a procedure to support OpenAPI the following _must_ be true:
+
+- Both `input` and `output` parsers are present AND use `Zod` validation.
+- Query `input` parsers extend `ZodObject<{ [string]: ZodString }>` or `ZodVoid`.
+- Mutation `input` parsers extend `ZodObject<{ [string]: ZodAnyType }>` or `ZodVoid`.
 - `meta.openapi.enabled` is set to `true`.
-- `meta.openapi.method` is `GET`, `DELETE` for queries OR `POST`, `PUT` or `PATCH` for mutations.
+- `meta.openapi.method` is `GET`, `DELETE` for query OR `POST`, `PUT` or `PATCH` for mutation.
 - `meta.openapi.path` is a string starting with `/`.
 - `meta.openapi.path` parameters exist in `input` parser as `ZodString`
 
@@ -112,7 +115,7 @@ Please note:
 
 Query procedures accept input via URL `query parameters`.
 
-Mutation procedures accept input via the `request body` as a `application/json` content type.
+Mutation procedures accept input via the `request body` with a `application/json` content type.
 
 ### Path parameters
 
@@ -187,7 +190,7 @@ Please see [error status codes here](src/adapters/node-http/errors.ts).
 
 ## Authorization
 
-To create protected endpoints, just add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request with the `createContext` function using the `Authorization` header with the `Bearer` scheme.
+To create protected endpoints, add `protect: true` to the `meta.openapi` object of each tRPC procedure. You can then authenticate each request with the `createContext` function using the `Authorization` header with the `Bearer` scheme.
 
 Explore a [complete example here](examples/with-nextjs/src/server/router.ts).
 
@@ -295,15 +298,15 @@ Please see [full typings here](src/generator/index.ts).
 
 Please see [full typings here](src/types.ts).
 
-| Property      | Type         | Description                                                                                                     | Required | Default     |
-| ------------- | ------------ | --------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `enabled`     | `boolean`    | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                                  | `true`   | `false`     |
-| `method`      | `HttpMethod` | Method this endpoint is exposed on. Value can be `GET`/`DELETE` for query OR `POST`/`PUT`/`PATCH` for mutation. | `true`   | `undefined` |
-| `path`        | `string`     | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.            | `true`   | `undefined` |
-| `protect`     | `boolean`    | Requires this endpoint to use an `Authorization` header credential with `Bearer` scheme on OpenAPI document.    | `false`  | `false`     |
-| `summary`     | `string`     | A short summary of the endpoint included in the OpenAPI document.                                               | `false`  | `undefined` |
-| `description` | `string`     | A verbose description of the endpoint included in the OpenAPI document.                                         | `false`  | `undefined` |
-| `tag`         | `string`     | A tag used for logical grouping of endpoints in the OpenAPI document.                                           | `false`  | `undefined` |
+| Property      | Type         | Description                                                                                                        | Required | Default     |
+| ------------- | ------------ | ------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
+| `enabled`     | `boolean`    | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                                     | `true`   | `false`     |
+| `method`      | `HttpMethod` | Method this endpoint is exposed on. Value can be `GET`/`DELETE` for queries OR `POST`/`PUT`/`PATCH` for mutations. | `true`   | `undefined` |
+| `path`        | `string`     | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.               | `true`   | `undefined` |
+| `protect`     | `boolean`    | Requires this endpoint to use an `Authorization` header credential with `Bearer` scheme on OpenAPI document.       | `false`  | `false`     |
+| `summary`     | `string`     | A short summary of the endpoint included in the OpenAPI document.                                                  | `false`  | `undefined` |
+| `description` | `string`     | A verbose description of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined` |
+| `tag`         | `string`     | A tag used for logical grouping of endpoints in the OpenAPI document.                                              | `false`  | `undefined` |
 
 #### CreateOpenApiNodeHttpHandlerOptions
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const body = await res.json(); /* { ok: true, data: { greeting: 'Hello James!' }
 Peer dependencies:
 
 - [`tRPC`](https://github.com/trpc/trpc) version 9 (`@trpc/server@^9.23.0`) must be installed.
-- [`Zod`](https://github.com/colinhacks/zod) version 3 (`zod@^3.0.0`) must be installed.
+- [`Zod`](https://github.com/colinhacks/zod) version 3 (`zod@^3.14.4`) must be installed.
 
 For a procedure to support OpenAPI the following _must_ be true:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "examples/*"
       ],
       "dependencies": {
-        "co-body": "^6.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "openapi-types": "^12.0.0",
-        "zod-to-json-schema": "^3.17.0"
+        "co-body": "6.1.0",
+        "lodash.clonedeep": "4.5.0",
+        "openapi-types": "12.0.0",
+        "zod-to-json-schema": "3.17.0"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
@@ -48,7 +48,7 @@
       },
       "peerDependencies": {
         "@trpc/server": "^9.23.0",
-        "zod": "^3.0.0"
+        "zod": "^3.14.4"
       }
     },
     "examples/with-express": {
@@ -15516,7 +15516,7 @@
         "@types/node-fetch": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
-        "co-body": "^6.1.0",
+        "co-body": "6.1.0",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -15524,11 +15524,11 @@
         "eslint-plugin-promise": "^6.0.0",
         "express": "^4.18.1",
         "jest": "^28.1.0",
-        "lodash.clonedeep": "^4.5.0",
+        "lodash.clonedeep": "4.5.0",
         "next": "^12.1.6",
         "node-fetch": "^2.6.7",
         "openapi-schema-validator": "^11.0.1",
-        "openapi-types": "^12.0.0",
+        "openapi-types": "12.0.0",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
         "superjson": "^1.9.1",
@@ -15538,7 +15538,7 @@
         "typescript": "^4.7.2",
         "with-express": "file:examples/with-express",
         "with-nextjs": "file:examples/with-nextjs",
-        "zod-to-json-schema": "^3.17.0"
+        "zod-to-json-schema": "3.17.0"
       },
       "dependencies": {
         "@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,12 @@
         ".",
         "examples/*"
       ],
+      "dependencies": {
+        "co-body": "^6.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "openapi-types": "^12.0.0",
+        "zod-to-json-schema": "^3.17.0"
+      },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^3.2.0",
         "@trpc/client": "^9.23.0",
@@ -42,11 +48,7 @@
       },
       "peerDependencies": {
         "@trpc/server": "^9.23.0",
-        "co-body": "^6.1.0",
-        "lodash.clonedeep": "^4.0.0",
-        "openapi-types": "^11.0.0",
-        "zod": "^3.0.0",
-        "zod-to-json-schema": "^3.17.0"
+        "zod": "^3.0.0"
       }
     },
     "examples/with-express": {
@@ -3064,7 +3066,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
       "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
-      "peer": true,
       "dependencies": {
         "inflation": "^2.0.0",
         "qs": "^6.5.2",
@@ -4908,7 +4909,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
       "integrity": "sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw==",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6474,8 +6474,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "peer": true
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -7035,10 +7034,16 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/openapi-schema-validator/node_modules/openapi-types": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.1.0.tgz",
+      "integrity": "sha512-ZW+Jf12flFF6DXSij8DGL3svDA4RtSyHXjC/xB/JAh18gg3uVfVIFLvCfScUMowrpvlkxsMMbErakbth2g3/iQ==",
+      "dev": true
+    },
     "node_modules/openapi-types": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.1.tgz",
-      "integrity": "sha512-P2pGRlHFXgP8z6vrp5P/MtftOXYtlIY1A+V0VmioOoo85NN6RSPgGbEprRAUNMIsbfRjnCPdx/r8mi8QRR7grQ=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -9154,7 +9159,6 @@
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.17.0.tgz",
       "integrity": "sha512-Ioxmh41HTo4xAip7DPy79ysvGibPnDxzGoPNcNT+1dxwLjeXf/BruRnj7sRJAe2p4z8vTx6d62CXigEPTz6DqQ==",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.14.4"
       }
@@ -11420,7 +11424,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
       "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
-      "peer": true,
       "requires": {
         "inflation": "^2.0.0",
         "qs": "^6.5.2",
@@ -12797,8 +12800,7 @@
     "inflation": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
-      "integrity": "sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw==",
-      "peer": true
+      "integrity": "sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -13982,8 +13984,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "peer": true
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -14379,13 +14380,19 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
+        },
+        "openapi-types": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.1.0.tgz",
+          "integrity": "sha512-ZW+Jf12flFF6DXSij8DGL3svDA4RtSyHXjC/xB/JAh18gg3uVfVIFLvCfScUMowrpvlkxsMMbErakbth2g3/iQ==",
+          "dev": true
         }
       }
     },
     "openapi-types": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.1.tgz",
-      "integrity": "sha512-P2pGRlHFXgP8z6vrp5P/MtftOXYtlIY1A+V0VmioOoo85NN6RSPgGbEprRAUNMIsbfRjnCPdx/r8mi8QRR7grQ=="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
     },
     "optionator": {
       "version": "0.9.1",
@@ -15509,6 +15516,7 @@
         "@types/node-fetch": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
+        "co-body": "^6.1.0",
         "eslint": "^8.16.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -15516,9 +15524,11 @@
         "eslint-plugin-promise": "^6.0.0",
         "express": "^4.18.1",
         "jest": "^28.1.0",
+        "lodash.clonedeep": "^4.5.0",
         "next": "^12.1.6",
         "node-fetch": "^2.6.7",
         "openapi-schema-validator": "^11.0.1",
+        "openapi-types": "^12.0.0",
         "prettier": "^2.6.2",
         "rimraf": "^3.0.2",
         "superjson": "^1.9.1",
@@ -15527,7 +15537,8 @@
         "ts-node": "^10.8.0",
         "typescript": "^4.7.2",
         "with-express": "file:examples/with-express",
-        "with-nextjs": "file:examples/with-nextjs"
+        "with-nextjs": "file:examples/with-nextjs",
+        "zod-to-json-schema": "^3.17.0"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -17789,7 +17800,6 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.1.0.tgz",
           "integrity": "sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==",
-          "peer": true,
           "requires": {
             "inflation": "^2.0.0",
             "qs": "^6.5.2",
@@ -19166,8 +19176,7 @@
         "inflation": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
-          "integrity": "sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw==",
-          "peer": true
+          "integrity": "sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw=="
         },
         "inflight": {
           "version": "1.0.6",
@@ -20351,8 +20360,7 @@
         "lodash.clonedeep": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-          "peer": true
+          "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
         },
         "lodash.debounce": {
           "version": "4.0.8",
@@ -20748,13 +20756,19 @@
               "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
               "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
               "dev": true
+            },
+            "openapi-types": {
+              "version": "11.1.0",
+              "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.1.0.tgz",
+              "integrity": "sha512-ZW+Jf12flFF6DXSij8DGL3svDA4RtSyHXjC/xB/JAh18gg3uVfVIFLvCfScUMowrpvlkxsMMbErakbth2g3/iQ==",
+              "dev": true
             }
           }
         },
         "openapi-types": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-11.0.1.tgz",
-          "integrity": "sha512-P2pGRlHFXgP8z6vrp5P/MtftOXYtlIY1A+V0VmioOoo85NN6RSPgGbEprRAUNMIsbfRjnCPdx/r8mi8QRR7grQ=="
+          "version": "12.0.0",
+          "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+          "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw=="
         },
         "optionator": {
           "version": "0.9.1",
@@ -22348,7 +22362,6 @@
           "version": "3.17.0",
           "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.17.0.tgz",
           "integrity": "sha512-Ioxmh41HTo4xAip7DPy79ysvGibPnDxzGoPNcNT+1dxwLjeXf/BruRnj7sRJAe2p4z8vTx6d62CXigEPTz6DqQ==",
-          "peer": true,
           "requires": {}
         }
       }
@@ -22836,7 +22849,6 @@
       "version": "3.17.0",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.17.0.tgz",
       "integrity": "sha512-Ioxmh41HTo4xAip7DPy79ysvGibPnDxzGoPNcNT+1dxwLjeXf/BruRnj7sRJAe2p4z8vTx6d62CXigEPTz6DqQ==",
-      "peer": true,
       "requires": {}
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.0",
+      "version": "0.1.1-alpha.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.1-alpha.1",
+      "version": "0.1.1-alpha.2",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.1-alpha.0",
+      "version": "0.1.1-alpha.1",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
   },
   "peerDependencies": {
     "@trpc/server": "^9.23.0",
+    "zod": "^3.0.0"
+  },
+  "dependencies": {
     "co-body": "^6.1.0",
-    "lodash.clonedeep": "^4.0.0",
-    "openapi-types": "^11.0.0",
-    "zod": "^3.0.0",
+    "lodash.clonedeep": "^4.5.0",
+    "openapi-types": "^12.0.0",
     "zod-to-json-schema": "^3.17.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.1-alpha.0",
+  "version": "0.1.1-alpha.1",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.0",
+  "version": "0.1.1-alpha.0",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "test": "tsc --noEmit && jest --verbose",
     "build": "rimraf dist && tsc -p tsconfig.build.json",
+    "release:alpha": "npm test && npm version prerelease --preid alpha && npm run build && npm publish",
     "release:patch": "npm test && npm version patch && npm run build && npm publish",
     "release:minor": "npm test && npm version minor && npm run build && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
   },
   "peerDependencies": {
     "@trpc/server": "^9.23.0",
-    "zod": "^3.0.0"
+    "zod": "^3.14.4"
   },
   "dependencies": {
-    "co-body": "^6.1.0",
-    "lodash.clonedeep": "^4.5.0",
-    "openapi-types": "^12.0.0",
-    "zod-to-json-schema": "^3.17.0"
+    "co-body": "6.1.0",
+    "lodash.clonedeep": "4.5.0",
+    "openapi-types": "12.0.0",
+    "zod-to-json-schema": "3.17.0"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1-alpha.2",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,


### PR DESCRIPTION
Raised here: https://discord.com/channels/867764511159091230/984783319805874196

## Yarn not installing `peerDependencies`

Added the following to `dependencies`
- "co-body": "6.1.0",
- "lodash.clonedeep": "4.5.0",
- "openapi-types": "12.0.0",
- "zod-to-json-schema": "3.17.0"