### PR TITLE
Feat/support number boolean date input params

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,18 @@ Please note:
 - Trailing slashes are ignored.
 - Routing is case-insensitive.
 
-### `ZodParameterType`
+#### `ZodParameterType`
 
-The following `ZodType`s are supported (see the [full typing here](src/types.ts)):
+The following `ZodType`s are supported ([full typing](src/types.ts)):
 
-- ZodString
-- ZodNumber
-- ZodBoolean
-- ZodDate
-- ZodLiteral
-- ZodEnum
-- ZodNativeEnum
-- ZodUnion
+- `ZodString`
+- `ZodNumber`
+- `ZodBoolean`
+- `ZodDate`
+- `ZodLiteral`
+- `ZodEnum`
+- `ZodNativeEnum`
+- `ZodUnion`
 
 ## HTTP Requests
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Please note:
 - Trailing slashes are ignored.
 - Routing is case-insensitive.
 
-#### ZodParameterType
+### `ZodParameterType`
 
-The following `ZodType`s are supported:
+The following `ZodType`s are supported (see the [full typing here](src/types.ts)):
 
 - ZodString
 - ZodNumber
@@ -123,8 +123,6 @@ The following `ZodType`s are supported:
 - ZodEnum
 - ZodNativeEnum
 - ZodUnion
-
-Please see the [full typing here](src/types.ts).
 
 ## HTTP Requests
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,11 @@ Please note:
 
 The following `ZodType`s are supported ([full typing](src/types.ts)):
 
-- `ZodString`
-- `ZodNumber`
-- `ZodBoolean`
-- `ZodDate`
-- `ZodLiteral`
-- `ZodEnum`
-- `ZodNativeEnum`
-- `ZodUnion`
+- `string`
+- `number`
+- `boolean`
+- `Date`
+- `enum`
 
 ## HTTP Requests
 

--- a/README.md
+++ b/README.md
@@ -98,18 +98,31 @@ Peer dependencies:
 For a procedure to support OpenAPI the following _must_ be true:
 
 - Both `input` and `output` parsers are present AND use `Zod` validation.
-- Query `input` parsers extend `ZodObject<{ [string]: ZodString }>` or `ZodVoid`.
+- Query `input` parsers extend `ZodObject<{ [string]: ZodParameterType }>` or `ZodVoid`.
 - Mutation `input` parsers extend `ZodObject<{ [string]: ZodAnyType }>` or `ZodVoid`.
 - `meta.openapi.enabled` is set to `true`.
 - `meta.openapi.method` is `GET`, `DELETE` for query OR `POST`, `PUT` or `PATCH` for mutation.
 - `meta.openapi.path` is a string starting with `/`.
-- `meta.openapi.path` parameters exist in `input` parser as `ZodString`
+- `meta.openapi.path` parameters exist in `input` parser as `ZodParameterType`
 
 Please note:
 
 - Data [`transformers`](https://trpc.io/docs/data-transformers) are ignored.
 - Trailing slashes are ignored.
 - Routing is case-insensitive.
+
+### `ZodParameterType`
+
+The following `ZodType`s are supported.
+
+- ZodString
+- ZodNumber
+- ZodBoolean
+- ZodDate
+- ZodLiteral
+- ZodEnum
+- ZodNativeEnum
+- ZodUnion
 
 ## HTTP Requests
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Please note:
 - Trailing slashes are ignored.
 - Routing is case-insensitive.
 
-### `ZodParameterType`
+#### ZodParameterType
 
-The following `ZodType`s are supported.
+The following `ZodType`s are supported:
 
 - ZodString
 - ZodNumber
@@ -123,6 +123,8 @@ The following `ZodType`s are supported.
 - ZodEnum
 - ZodNativeEnum
 - ZodUnion
+
+Please see the [full typing here](src/types.ts).
 
 ## HTTP Requests
 

--- a/examples/with-nextjs/src/server/router.ts
+++ b/examples/with-nextjs/src/server/router.ts
@@ -179,7 +179,7 @@ const usersRouter = createRouter()
       },
     },
     input: z.object({
-      id: z.string().uuid(),
+      id: z.number(),
     }),
     output: z.object({
       user: z.object({
@@ -189,7 +189,8 @@ const usersRouter = createRouter()
       }),
     }),
     resolve: ({ input }) => {
-      const user = database.users.find((_user) => _user.id === input.id);
+      const id = input.id.toString();
+      const user = database.users.find((_user) => _user.id === id);
 
       if (!user) {
         throw new TRPCError({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.2.0",
+      "version": "0.2.1-alpha.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.2",
+      "version": "0.1.3-alpha.0",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.3-alpha.0",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trpc-openapi",
-      "version": "0.1.3-alpha.0",
+      "version": "0.1.3",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.2.0",
+  "version": "0.2.1-alpha.0",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.3-alpha.0",
+  "version": "0.1.3",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trpc-openapi",
-  "version": "0.1.2",
+  "version": "0.1.3-alpha.0",
   "description": "tRPC OpenAPI",
   "author": "James Berry <jb@jamesbe.com>",
   "private": false,

--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -17,7 +17,7 @@ import {
 import { normalizePath } from '../../utils';
 import { TRPC_ERROR_CODE_HTTP_STATUS, getErrorFromUnknown } from './errors';
 import { getBody, getQuery } from './input';
-import { monkeyPatchVoidInputs } from './monkeyPatch';
+import { monkeyPatchParameterInputs, monkeyPatchVoidInputs } from './monkeyPatch';
 import { createMatchProcedureFn } from './procedures';
 
 export type CreateOpenApiNodeHttpHandlerOptions<
@@ -42,7 +42,10 @@ export const createOpenApiNodeHttpHandler = <
 
   // Validate router
   generateOpenApiDocument(router, { title: '-', version: '-', baseUrl: '-' });
+
+  // monkey patches
   monkeyPatchVoidInputs(router);
+  monkeyPatchParameterInputs(router);
 
   const { createContext, responseMeta, onError, teardown, maxBodySize } = opts;
   const matchProcedure = createMatchProcedureFn(router);

--- a/src/adapters/node-http/monkeyPatch.ts
+++ b/src/adapters/node-http/monkeyPatch.ts
@@ -25,7 +25,7 @@ export const monkeyPatchVoidInputs = (appRouter: OpenApiRouter) => {
 
     const { inputParser } = getInputOutputParsers(query);
     if (instanceofZodTypeLikeVoid(inputParser)) {
-      (query as any).parseInputFn = zObject.parse.bind(zObject);
+      (query as any).parseInputFn = zObject.parseAsync.bind(zObject);
     }
   }
 
@@ -38,7 +38,7 @@ export const monkeyPatchVoidInputs = (appRouter: OpenApiRouter) => {
 
     const { inputParser } = getInputOutputParsers(mutation);
     if (instanceofZodTypeLikeVoid(inputParser)) {
-      (mutation as any).parseInputFn = zObject.parse.bind(zObject);
+      (mutation as any).parseInputFn = zObject.parseAsync.bind(zObject);
     }
   }
 };
@@ -92,7 +92,7 @@ export const monkeyPatchParameterInputs = (appRouter: OpenApiRouter) => {
           return;
         }
       });
-      (query as any).parseInputFn = zObject.parse.bind(zObject);
+      (query as any).parseInputFn = zObject.parseAsync.bind(zObject);
     }
   }
 
@@ -134,7 +134,7 @@ export const monkeyPatchParameterInputs = (appRouter: OpenApiRouter) => {
           return;
         }
       });
-      (mutation as any).parseInputFn = zObject.parse.bind(zObject);
+      (mutation as any).parseInputFn = zObject.parseAsync.bind(zObject);
     }
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,17 +3,7 @@ import { ProcedureRecord } from '@trpc/server';
 import { DefaultErrorShape, Router } from '@trpc/server/dist/declarations/src/router';
 // eslint-disable-next-line import/no-unresolved
 import { TRPC_ERROR_CODE_KEY } from '@trpc/server/dist/declarations/src/rpc';
-import {
-  ZodBoolean,
-  ZodDate,
-  ZodEnum,
-  ZodIssue,
-  ZodLiteral,
-  ZodNativeEnum,
-  ZodNumber,
-  ZodString,
-  ZodUnion,
-} from 'zod';
+import { z } from 'zod';
 
 export type OpenApiMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
@@ -49,18 +39,63 @@ export type OpenApiErrorResponse = {
   error: {
     message: string;
     code: TRPC_ERROR_CODE_KEY;
-    issues?: ZodIssue[];
+    issues?: z.ZodIssue[];
   };
 };
 
 export type OpenApiResponse<D = any> = OpenApiSuccessResponse<D> | OpenApiErrorResponse;
 
+export type ZodParameterTypeLikeVoid = z.ZodVoid | z.ZodUndefined | z.ZodNever;
+
+type NativeEnumType = {
+  [k: string]: string | number;
+  [nu: number]: string;
+};
+
+export type ZodParameterTypeLikeString =
+  | z.ZodString
+  | z.ZodLiteral<string>
+  | z.ZodEnum<[string, ...string[]]>
+  | z.ZodNativeEnum<NativeEnumType>
+  | z.ZodOptional<ZodParameterTypeLikeString>
+  | z.ZodDefault<ZodParameterTypeLikeString>
+  | z.ZodEffects<ZodParameterTypeLikeString, unknown, unknown>
+  | z.ZodUnion<[ZodParameterTypeLikeString, ...ZodParameterTypeLikeString[]]>
+  | z.ZodIntersection<ZodParameterTypeLikeString, ZodParameterTypeLikeString>
+  | z.ZodLazy<ZodParameterTypeLikeString>;
+
+export type ZodParameterTypeLikeNumber =
+  | z.ZodNumber
+  | z.ZodLiteral<number>
+  | z.ZodNativeEnum<NativeEnumType>
+  | z.ZodOptional<ZodParameterTypeLikeNumber>
+  | z.ZodDefault<ZodParameterTypeLikeNumber>
+  | z.ZodEffects<ZodParameterTypeLikeNumber, unknown, unknown>
+  | z.ZodUnion<[ZodParameterTypeLikeNumber, ...ZodParameterTypeLikeNumber[]]>
+  | z.ZodIntersection<ZodParameterTypeLikeNumber, ZodParameterTypeLikeNumber>
+  | z.ZodLazy<ZodParameterTypeLikeNumber>;
+
+export type ZodParameterTypeLikeBoolean =
+  | z.ZodBoolean
+  | z.ZodLiteral<boolean>
+  | z.ZodOptional<ZodParameterTypeLikeBoolean>
+  | z.ZodDefault<ZodParameterTypeLikeBoolean>
+  | z.ZodEffects<ZodParameterTypeLikeBoolean, unknown, unknown>
+  | z.ZodUnion<[ZodParameterTypeLikeBoolean, ...ZodParameterTypeLikeBoolean[]]>
+  | z.ZodIntersection<ZodParameterTypeLikeBoolean, ZodParameterTypeLikeBoolean>
+  | z.ZodLazy<ZodParameterTypeLikeBoolean>;
+
+export type ZodParameterTypeLikeDate =
+  | z.ZodDate
+  | z.ZodOptional<ZodParameterTypeLikeDate>
+  | z.ZodDefault<ZodParameterTypeLikeDate>
+  | z.ZodEffects<ZodParameterTypeLikeDate, unknown, unknown>
+  | z.ZodUnion<[ZodParameterTypeLikeDate, ...ZodParameterTypeLikeDate[]]>
+  | z.ZodIntersection<ZodParameterTypeLikeDate, ZodParameterTypeLikeDate>
+  | z.ZodLazy<ZodParameterTypeLikeDate>;
+
 export type ZodParameterType =
-  | ZodString
-  | ZodNumber
-  | ZodBoolean
-  | ZodDate
-  | ZodLiteral<string | number | boolean>
-  | ZodEnum<[string, ...string[]]>
-  | ZodNativeEnum<{ [k: string]: string | number; [nu: number]: string }>
-  | ZodUnion<[ZodParameterType]>;
+  | ZodParameterTypeLikeString
+  | ZodParameterTypeLikeNumber
+  | ZodParameterTypeLikeBoolean
+  | ZodParameterTypeLikeDate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,17 @@ import { ProcedureRecord } from '@trpc/server';
 import { DefaultErrorShape, Router } from '@trpc/server/dist/declarations/src/router';
 // eslint-disable-next-line import/no-unresolved
 import { TRPC_ERROR_CODE_KEY } from '@trpc/server/dist/declarations/src/rpc';
-import { ZodIssue } from 'zod';
+import {
+  ZodBoolean,
+  ZodDate,
+  ZodEnum,
+  ZodIssue,
+  ZodLiteral,
+  ZodNativeEnum,
+  ZodNumber,
+  ZodString,
+  ZodUnion,
+} from 'zod';
 
 export type OpenApiMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
@@ -44,3 +54,16 @@ export type OpenApiErrorResponse = {
 };
 
 export type OpenApiResponse<D = any> = OpenApiSuccessResponse<D> | OpenApiErrorResponse;
+
+export type ZodParameterType =
+  | ZodString
+  | ZodNumber
+  | ZodBoolean
+  | ZodDate
+  | ZodLiteral<string | number | boolean | Date>
+  | ZodEnum<[string, ...string[]]>
+  | ZodNativeEnum<{ [k: string]: string | number; [nu: number]: string }>
+  | ZodUnion<[ZodString, ...ZodString[]]>
+  | ZodUnion<[ZodNumber, ...ZodNumber[]]>
+  | ZodUnion<[ZodBoolean, ...ZodBoolean[]]>
+  | ZodUnion<[ZodDate, ...ZodDate[]]>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,10 +60,7 @@ export type ZodParameterType =
   | ZodNumber
   | ZodBoolean
   | ZodDate
-  | ZodLiteral<string | number | boolean | Date>
+  | ZodLiteral<string | number | boolean>
   | ZodEnum<[string, ...string[]]>
   | ZodNativeEnum<{ [k: string]: string | number; [nu: number]: string }>
-  | ZodUnion<[ZodString, ...ZodString[]]>
-  | ZodUnion<[ZodNumber, ...ZodNumber[]]>
-  | ZodUnion<[ZodBoolean, ...ZodBoolean[]]>
-  | ZodUnion<[ZodDate, ...ZodDate[]]>;
+  | ZodUnion<[ZodParameterType]>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,15 @@
 import { Procedure } from '@trpc/server/dist/declarations/src/internals/procedure';
 import { z } from 'zod';
 
+import {
+  ZodParameterType,
+  ZodParameterTypeLikeBoolean,
+  ZodParameterTypeLikeDate,
+  ZodParameterTypeLikeNumber,
+  ZodParameterTypeLikeString,
+  ZodParameterTypeLikeVoid,
+} from './types';
+
 // `inputParser` & `outputParser` are private so this is a hack to access it
 export const getInputOutputParsers = (procedure: Procedure<any, any, any, any, any, any, any>) => {
   return procedure as unknown as {
@@ -34,17 +43,17 @@ export const instanceofZodTypeKind = <Z extends z.ZodFirstPartyTypeKind>(
   return type?._def?.typeName === zodTypeKind;
 };
 
-export const instanceofZodTypeObject = (type: z.ZodTypeAny): type is z.ZodObject<z.ZodRawShape> => {
-  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodObject);
-};
-
 export const instanceofZodTypeOptional = (
   type: z.ZodTypeAny,
 ): type is z.ZodOptional<z.ZodTypeAny> => {
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional);
 };
 
-export const instanceofZodTypeLikeVoid = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeObject = (type: z.ZodTypeAny): type is z.ZodObject<z.ZodRawShape> => {
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodObject);
+};
+
+export const instanceofZodTypeLikeVoid = (type: z.ZodTypeAny): type is ZodParameterTypeLikeVoid => {
   return (
     instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodVoid) ||
     instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUndefined) ||
@@ -52,7 +61,9 @@ export const instanceofZodTypeLikeVoid = (type: z.ZodTypeAny): boolean => {
   );
 };
 
-export const instanceofZodTypeLikeString = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeLikeString = (
+  type: z.ZodTypeAny,
+): type is ZodParameterTypeLikeString => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
     return instanceofZodTypeLikeString(type.unwrap());
   }
@@ -62,22 +73,32 @@ export const instanceofZodTypeLikeString = (type: z.ZodTypeAny): boolean => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
     return instanceofZodTypeLikeString(type.innerType());
   }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
+    return !type._def.options.some((option) => !instanceofZodTypeLikeString(option));
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodIntersection)) {
+    return (
+      instanceofZodTypeLikeString(type._def.left) && instanceofZodTypeLikeString(type._def.right)
+    );
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLazy)) {
+    return instanceofZodTypeLikeString(type._def.getter());
+  }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
     return typeof type._def.value === 'string';
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEnum)) {
-    return !type._def.values.some((value) => typeof value !== 'string');
+    return true;
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNativeEnum)) {
-    return !Object.values(type._def.values).some((value) => typeof value !== 'string');
-  }
-  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
-    return !type._def.options.some((option) => !instanceofZodTypeLikeString(option));
+    return !Object.values(type._def.values).some((value) => typeof value === 'number');
   }
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodString);
 };
 
-export const instanceofZodTypeLikeNumber = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeLikeNumber = (
+  type: z.ZodTypeAny,
+): type is ZodParameterTypeLikeNumber => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
     return instanceofZodTypeLikeNumber(type.unwrap());
   }
@@ -87,19 +108,29 @@ export const instanceofZodTypeLikeNumber = (type: z.ZodTypeAny): boolean => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
     return instanceofZodTypeLikeNumber(type.innerType());
   }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
+    return !type._def.options.some((option) => !instanceofZodTypeLikeNumber(option));
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodIntersection)) {
+    return (
+      instanceofZodTypeLikeNumber(type._def.left) && instanceofZodTypeLikeNumber(type._def.right)
+    );
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLazy)) {
+    return instanceofZodTypeLikeNumber(type._def.getter());
+  }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
     return typeof type._def.value === 'number';
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNativeEnum)) {
-    return !Object.values(type._def.values).some((value) => typeof value !== 'number');
-  }
-  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
-    return !type._def.options.some((option) => !instanceofZodTypeLikeNumber(option));
+    return Object.values(type._def.values).some((value) => typeof value === 'number');
   }
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNumber);
 };
 
-export const instanceofZodTypeLikeBoolean = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeLikeBoolean = (
+  type: z.ZodTypeAny,
+): type is ZodParameterTypeLikeBoolean => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
     return instanceofZodTypeLikeBoolean(type.unwrap());
   }
@@ -108,6 +139,17 @@ export const instanceofZodTypeLikeBoolean = (type: z.ZodTypeAny): boolean => {
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
     return instanceofZodTypeLikeBoolean(type.innerType());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
+    return !type._def.options.some((option) => !instanceofZodTypeLikeBoolean(option));
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodIntersection)) {
+    return (
+      instanceofZodTypeLikeBoolean(type._def.left) && instanceofZodTypeLikeBoolean(type._def.right)
+    );
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLazy)) {
+    return instanceofZodTypeLikeBoolean(type._def.getter());
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
     return typeof type._def.value === 'boolean';
@@ -115,20 +157,29 @@ export const instanceofZodTypeLikeBoolean = (type: z.ZodTypeAny): boolean => {
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodBoolean);
 };
 
-export const instanceofZodTypeLikeDate = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeLikeDate = (type: z.ZodTypeAny): type is ZodParameterTypeLikeDate => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
-    return instanceofZodTypeLikeBoolean(type.unwrap());
+    return instanceofZodTypeLikeDate(type.unwrap());
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDefault)) {
-    return instanceofZodTypeLikeBoolean(type.removeDefault());
+    return instanceofZodTypeLikeDate(type.removeDefault());
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
-    return instanceofZodTypeLikeBoolean(type.innerType());
+    return instanceofZodTypeLikeDate(type.innerType());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
+    return !type._def.options.some((option) => !instanceofZodTypeLikeDate(option));
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodIntersection)) {
+    return instanceofZodTypeLikeDate(type._def.left) && instanceofZodTypeLikeDate(type._def.right);
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLazy)) {
+    return instanceofZodTypeLikeDate(type._def.getter());
   }
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDate);
 };
 
-export const instanceofZodTypeLikeParameter = (type: z.ZodTypeAny): boolean => {
+export const instanceofZodTypeLikeParameter = (type: z.ZodTypeAny): type is ZodParameterType => {
   return (
     instanceofZodTypeLikeString(type) ||
     instanceofZodTypeLikeNumber(type) ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export const getPathRegExp = (path: string) => {
   return new RegExp(`^${groupedExp}$`, 'i');
 };
 
-export const instanceofZod = (type: any): type is z.ZodTypeAny => {
+export const instanceofZodType = (type: any): type is z.ZodTypeAny => {
   return !!type?._def?.typeName;
 };
 
@@ -34,18 +34,22 @@ export const instanceofZodTypeKind = <Z extends z.ZodFirstPartyTypeKind>(
   return type?._def?.typeName === zodTypeKind;
 };
 
+export const instanceofZodTypeObject = (type: z.ZodTypeAny): type is z.ZodObject<z.ZodRawShape> => {
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodObject);
+};
+
+export const instanceofZodTypeOptional = (
+  type: z.ZodTypeAny,
+): type is z.ZodOptional<z.ZodTypeAny> => {
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional);
+};
+
 export const instanceofZodTypeLikeVoid = (type: z.ZodTypeAny): boolean => {
   return (
     instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodVoid) ||
     instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUndefined) ||
     instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNever)
   );
-};
-
-export const instanceofZodTypeLikeObject = (
-  type: z.ZodTypeAny,
-): type is z.ZodObject<z.ZodRawShape> => {
-  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodObject);
 };
 
 export const instanceofZodTypeLikeString = (type: z.ZodTypeAny): boolean => {
@@ -58,14 +62,14 @@ export const instanceofZodTypeLikeString = (type: z.ZodTypeAny): boolean => {
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
     return instanceofZodTypeLikeString(type.innerType());
   }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
+    return typeof type._def.value === 'string';
+  }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEnum)) {
     return !type._def.values.some((value) => typeof value !== 'string');
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNativeEnum)) {
     return !Object.values(type._def.values).some((value) => typeof value !== 'string');
-  }
-  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
-    return typeof type._def.value === 'string';
   }
   if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
     return !type._def.options.some((option) => !instanceofZodTypeLikeString(option));
@@ -73,8 +77,62 @@ export const instanceofZodTypeLikeString = (type: z.ZodTypeAny): boolean => {
   return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodString);
 };
 
-export const instanceofZodTypeLikeOptional = (
-  type: z.ZodTypeAny,
-): type is z.ZodOptional<z.ZodTypeAny> => {
-  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional);
+export const instanceofZodTypeLikeNumber = (type: z.ZodTypeAny): boolean => {
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
+    return instanceofZodTypeLikeNumber(type.unwrap());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDefault)) {
+    return instanceofZodTypeLikeNumber(type.removeDefault());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
+    return instanceofZodTypeLikeNumber(type.innerType());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
+    return typeof type._def.value === 'number';
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNativeEnum)) {
+    return !Object.values(type._def.values).some((value) => typeof value !== 'number');
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodUnion)) {
+    return !type._def.options.some((option) => !instanceofZodTypeLikeNumber(option));
+  }
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodNumber);
+};
+
+export const instanceofZodTypeLikeBoolean = (type: z.ZodTypeAny): boolean => {
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
+    return instanceofZodTypeLikeBoolean(type.unwrap());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDefault)) {
+    return instanceofZodTypeLikeBoolean(type.removeDefault());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
+    return instanceofZodTypeLikeBoolean(type.innerType());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodLiteral)) {
+    return typeof type._def.value === 'boolean';
+  }
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodBoolean);
+};
+
+export const instanceofZodTypeLikeDate = (type: z.ZodTypeAny): boolean => {
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodOptional)) {
+    return instanceofZodTypeLikeBoolean(type.unwrap());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDefault)) {
+    return instanceofZodTypeLikeBoolean(type.removeDefault());
+  }
+  if (instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodEffects)) {
+    return instanceofZodTypeLikeBoolean(type.innerType());
+  }
+  return instanceofZodTypeKind(type, z.ZodFirstPartyTypeKind.ZodDate);
+};
+
+export const instanceofZodTypeLikeParameter = (type: z.ZodTypeAny): boolean => {
+  return (
+    instanceofZodTypeLikeString(type) ||
+    instanceofZodTypeLikeNumber(type) ||
+    instanceofZodTypeLikeBoolean(type) ||
+    instanceofZodTypeLikeDate(type)
+  );
 };

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -6,9 +6,6 @@ import { z } from 'zod';
 import { OpenApiMeta, generateOpenApiDocument, openApiVersion } from '../src';
 
 // TODO: test for duplicate paths (using getPathRegExp)
-// TODO: ZodRecord
-// TODO: ZodLazy
-// TODO: ZodIntersection
 
 const openApiSchemaValidator = new openAPISchemaValidator({ version: openApiVersion });
 
@@ -285,95 +282,492 @@ describe('generator', () => {
   });
 
   test('with ZodParameterType query input', () => {
-    // ZodString
-    // ZodNumber
-    // ZodBoolean
-    // ZodDate
-    // ZodLiteral
-    // ZodEnum
-    // ZodNativeEnum
-    // ZodUnion
+    {
+      enum NativeStringEnum {
+        James = 'James',
+        jlalmes = 'jlalmes',
+      }
 
-    enum NativeStringEnum {
-      A = 'A',
-      B = 'B',
-      C = 'C',
-    }
-    enum NativeNumberEnum {
-      X,
-      Y,
-      Z,
-    }
+      const likeStringRouter = trpc
+        .router<any, OpenApiMeta>()
+        .query('string', {
+          meta: { openapi: { enabled: true, path: '/string', method: 'GET' } },
+          input: z.object({ name: z.string() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringOptional', {
+          meta: { openapi: { enabled: true, path: '/string-optional', method: 'GET' } },
+          input: z.object({ name: z.string().optional() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringDefault', {
+          meta: { openapi: { enabled: true, path: '/string-default', method: 'GET' } },
+          input: z.object({ name: z.string().default('James') }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringPreprocess', {
+          meta: { openapi: { enabled: true, path: '/string-preprocess', method: 'GET' } },
+          input: z.object({ name: z.preprocess((arg) => arg, z.string()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringLiteral', {
+          meta: { openapi: { enabled: true, path: '/string-literal', method: 'GET' } },
+          input: z.object({ name: z.literal('James') }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringEnum', {
+          meta: { openapi: { enabled: true, path: '/string-enum', method: 'GET' } },
+          input: z.object({ name: z.enum(['James', 'jlalmes']) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringNativeEnum', {
+          meta: { openapi: { enabled: true, path: '/string-native-enum', method: 'GET' } },
+          input: z.object({ name: z.nativeEnum(NativeStringEnum) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringUnion', {
+          meta: { openapi: { enabled: true, path: '/string-union', method: 'GET' } },
+          input: z.object({ name: z.union([z.literal('James'), z.literal('jlalmes')]) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringIntersection', {
+          meta: { openapi: { enabled: true, path: '/string-intersection', method: 'GET' } },
+          input: z.object({
+            name: z.intersection(
+              z.union([z.literal('a'), z.literal('b')]),
+              z.union([z.literal('b'), z.literal('c')]),
+            ),
+          }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('stringLazy', {
+          meta: { openapi: { enabled: true, path: '/string-lazy', method: 'GET' } },
+          input: z.object({ name: z.lazy(() => z.string()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        });
 
-    const appRouter = trpc
-      .router<any, OpenApiMeta>()
-      .query('ZodString', {
-        meta: { openapi: { enabled: true, path: '/zod-string', method: 'GET' } },
-        input: z.object({ name: z.string() }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodNumber', {
-        meta: { openapi: { enabled: true, path: '/zod-number', method: 'GET' } },
-        input: z.object({ name: z.number() }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodBoolean', {
-        meta: { openapi: { enabled: true, path: '/zod-boolean', method: 'GET' } },
-        input: z.object({ name: z.boolean() }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodDate', {
-        meta: { openapi: { enabled: true, path: '/zod-date', method: 'GET' } },
-        input: z.object({ name: z.date() }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodLiteral.String', {
-        meta: { openapi: { enabled: true, path: '/zod-literal-string', method: 'GET' } },
-        input: z.object({ name: z.literal('string') }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodLiteral.Number', {
-        meta: { openapi: { enabled: true, path: '/zod-literal-number', method: 'GET' } },
-        input: z.object({ name: z.literal(1234) }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodLiteral.Boolean', {
-        meta: { openapi: { enabled: true, path: '/zod-literal-boolean', method: 'GET' } },
-        input: z.object({ name: z.literal(true) }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodEnum', {
-        meta: { openapi: { enabled: true, path: '/zod-enum', method: 'GET' } },
-        input: z.object({ name: z.enum(['James', 'jlalmes']) }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodNativeEnum.String', {
-        meta: { openapi: { enabled: true, path: '/zod-native-enum-string', method: 'GET' } },
-        input: z.object({ name: z.nativeEnum(NativeStringEnum) }),
-        output: z.void(),
-        resolve: () => undefined,
-      })
-      .query('ZodNativeEnum.Number', {
-        meta: { openapi: { enabled: true, path: '/zod-native-enum-number', method: 'GET' } },
-        input: z.object({ name: z.nativeEnum(NativeNumberEnum) }),
-        output: z.void(),
-        resolve: () => undefined,
+      const openApiDocument = generateOpenApiDocument(likeStringRouter, {
+        title: 'tRPC OpenAPI',
+        version: '1.0.0',
+        baseUrl: 'http://localhost:3000/api',
       });
-    // TODO:
-    // .query('ZodUnion.String', {
-    //   meta: { openapi: { enabled: true, path: '/zod-union-string', method: 'GET' } },
-    //   input: z.object({ name: z.union([z.string(), 'jlalmes']) }),
-    //   output: z.void(),
-    //   resolve: () => undefined,
-    // });
+
+      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+      expect((openApiDocument.paths['/string']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+      });
+      expect(
+        (openApiDocument.paths['/string-optional']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+      });
+      expect(
+        (openApiDocument.paths['/string-default']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+        default: 'James',
+      });
+      expect(
+        (openApiDocument.paths['/string-preprocess']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+      });
+      expect(
+        (openApiDocument.paths['/string-literal']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+        enum: ['James'],
+      });
+      expect((openApiDocument.paths['/string-enum']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+        enum: ['James', 'jlalmes'],
+      });
+      expect(
+        (openApiDocument.paths['/string-native-enum']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+        enum: ['James', 'jlalmes'],
+      });
+      expect((openApiDocument.paths['/string-union']!.get!.parameters![0]! as any).schema).toEqual({
+        anyOf: [
+          { type: 'string', enum: ['James'] },
+          { type: 'string', enum: ['jlalmes'] },
+        ],
+      });
+      expect(
+        (openApiDocument.paths['/string-intersection']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        allOf: [
+          {
+            anyOf: [
+              { type: 'string', enum: ['a'] },
+              { type: 'string', enum: ['b'] },
+            ],
+          },
+          {
+            anyOf: [
+              { type: 'string', enum: ['b'] },
+              { type: 'string', enum: ['c'] },
+            ],
+          },
+        ],
+      });
+      expect((openApiDocument.paths['/string-lazy']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+      });
+    }
+    {
+      enum NativeNumberEnum {
+        James,
+        jlalmes,
+      }
+
+      const numberLikeRouter = trpc
+        .router<any, OpenApiMeta>()
+        .query('number', {
+          meta: { openapi: { enabled: true, path: '/number', method: 'GET' } },
+          input: z.object({ name: z.number() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberOptional', {
+          meta: { openapi: { enabled: true, path: '/number-optional', method: 'GET' } },
+          input: z.object({ name: z.number().optional() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberDefault', {
+          meta: { openapi: { enabled: true, path: '/number-default', method: 'GET' } },
+          input: z.object({ name: z.number().default(123) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberPreprocess', {
+          meta: { openapi: { enabled: true, path: '/number-preprocess', method: 'GET' } },
+          input: z.object({ name: z.preprocess((arg) => arg, z.number()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberLiteral', {
+          meta: { openapi: { enabled: true, path: '/number-literal', method: 'GET' } },
+          input: z.object({ name: z.literal(123) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberNativeEnum', {
+          meta: { openapi: { enabled: true, path: '/number-native-enum', method: 'GET' } },
+          input: z.object({ name: z.nativeEnum(NativeNumberEnum) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberUnion', {
+          meta: { openapi: { enabled: true, path: '/number-union', method: 'GET' } },
+          input: z.object({ name: z.union([z.literal(123), z.literal(456)]) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberIntersection', {
+          meta: { openapi: { enabled: true, path: '/number-intersection', method: 'GET' } },
+          input: z.object({
+            name: z.intersection(
+              z.union([z.literal(1), z.literal(2)]),
+              z.union([z.literal(2), z.literal(3)]),
+            ),
+          }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('numberLazy', {
+          meta: { openapi: { enabled: true, path: '/number-lazy', method: 'GET' } },
+          input: z.object({ name: z.lazy(() => z.number()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        });
+
+      const openApiDocument = generateOpenApiDocument(numberLikeRouter, {
+        title: 'tRPC OpenAPI',
+        version: '1.0.0',
+        baseUrl: 'http://localhost:3000/api',
+      });
+
+      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+      expect((openApiDocument.paths['/number']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'number',
+      });
+      expect(
+        (openApiDocument.paths['/number-optional']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'number',
+      });
+      expect(
+        (openApiDocument.paths['/number-default']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'number',
+        default: 123,
+      });
+      expect(
+        (openApiDocument.paths['/number-preprocess']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'number',
+      });
+      expect(
+        (openApiDocument.paths['/number-literal']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'number',
+        enum: [123],
+      });
+      expect(
+        (openApiDocument.paths['/number-native-enum']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'number',
+        enum: [0, 1],
+      });
+      expect((openApiDocument.paths['/number-union']!.get!.parameters![0]! as any).schema).toEqual({
+        anyOf: [
+          { type: 'number', enum: [123] },
+          { type: 'number', enum: [456] },
+        ],
+      });
+      expect(
+        (openApiDocument.paths['/number-intersection']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        allOf: [
+          {
+            anyOf: [
+              { type: 'number', enum: [1] },
+              { type: 'number', enum: [2] },
+            ],
+          },
+          {
+            anyOf: [
+              { type: 'number', enum: [2] },
+              { type: 'number', enum: [3] },
+            ],
+          },
+        ],
+      });
+      expect((openApiDocument.paths['/number-lazy']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'number',
+      });
+    }
+    {
+      const booleanLikeRouter = trpc
+        .router<any, OpenApiMeta>()
+        .query('boolean', {
+          meta: { openapi: { enabled: true, path: '/boolean', method: 'GET' } },
+          input: z.object({ name: z.boolean() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanOptional', {
+          meta: { openapi: { enabled: true, path: '/boolean-optional', method: 'GET' } },
+          input: z.object({ name: z.boolean().optional() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanDefault', {
+          meta: { openapi: { enabled: true, path: '/boolean-default', method: 'GET' } },
+          input: z.object({ name: z.boolean().default(true) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanPreprocess', {
+          meta: { openapi: { enabled: true, path: '/boolean-preprocess', method: 'GET' } },
+          input: z.object({ name: z.preprocess((arg) => arg, z.boolean()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanLiteral', {
+          meta: { openapi: { enabled: true, path: '/boolean-literal', method: 'GET' } },
+          input: z.object({ name: z.literal(true) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanUnion', {
+          meta: { openapi: { enabled: true, path: '/boolean-union', method: 'GET' } },
+          input: z.object({ name: z.union([z.literal(true), z.literal(false)]) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanIntersection', {
+          meta: { openapi: { enabled: true, path: '/boolean-intersection', method: 'GET' } },
+          input: z.object({
+            name: z.intersection(z.union([z.literal(true), z.literal(false)]), z.literal(true)),
+          }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('booleanLazy', {
+          meta: { openapi: { enabled: true, path: '/boolean-lazy', method: 'GET' } },
+          input: z.object({ name: z.lazy(() => z.boolean()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        });
+
+      const openApiDocument = generateOpenApiDocument(booleanLikeRouter, {
+        title: 'tRPC OpenAPI',
+        version: '1.0.0',
+        baseUrl: 'http://localhost:3000/api',
+      });
+
+      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+      expect((openApiDocument.paths['/boolean']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'boolean',
+      });
+      expect(
+        (openApiDocument.paths['/boolean-optional']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'boolean',
+      });
+      expect(
+        (openApiDocument.paths['/boolean-default']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'boolean',
+        default: true,
+      });
+      expect(
+        (openApiDocument.paths['/boolean-preprocess']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'boolean',
+      });
+      expect(
+        (openApiDocument.paths['/boolean-literal']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'boolean',
+        enum: [true],
+      });
+      expect((openApiDocument.paths['/boolean-union']!.get!.parameters![0]! as any).schema).toEqual(
+        {
+          anyOf: [
+            { type: 'boolean', enum: [true] },
+            { type: 'boolean', enum: [false] },
+          ],
+        },
+      );
+      expect(
+        (openApiDocument.paths['/boolean-intersection']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        allOf: [
+          {
+            anyOf: [
+              { type: 'boolean', enum: [true] },
+              { type: 'boolean', enum: [false] },
+            ],
+          },
+          { type: 'boolean', enum: [true] },
+        ],
+      });
+      expect((openApiDocument.paths['/boolean-lazy']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'boolean',
+      });
+    }
+    {
+      const now = new Date();
+
+      const dateLikeRouter = trpc
+        .router<any, OpenApiMeta>()
+        .query('date', {
+          meta: { openapi: { enabled: true, path: '/date', method: 'GET' } },
+          input: z.object({ name: z.date() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('dateOptional', {
+          meta: { openapi: { enabled: true, path: '/date-optional', method: 'GET' } },
+          input: z.object({ name: z.date().optional() }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('dateDefault', {
+          meta: { openapi: { enabled: true, path: '/date-default', method: 'GET' } },
+          input: z.object({ name: z.date().default(now) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('datePreprocess', {
+          meta: { openapi: { enabled: true, path: '/date-preprocess', method: 'GET' } },
+          input: z.object({ name: z.preprocess((arg) => arg, z.date()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('dateUnion', {
+          meta: { openapi: { enabled: true, path: '/date-union', method: 'GET' } },
+          input: z.object({ name: z.union([z.date(), z.date()]) }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('dateIntersection', {
+          meta: { openapi: { enabled: true, path: '/date-intersection', method: 'GET' } },
+          input: z.object({
+            name: z.intersection(z.date(), z.date()),
+          }),
+          output: z.void(),
+          resolve: () => undefined,
+        })
+        .query('dateLazy', {
+          meta: { openapi: { enabled: true, path: '/date-lazy', method: 'GET' } },
+          input: z.object({ name: z.lazy(() => z.date()) }),
+          output: z.void(),
+          resolve: () => undefined,
+        });
+
+      const openApiDocument = generateOpenApiDocument(dateLikeRouter, {
+        title: 'tRPC OpenAPI',
+        version: '1.0.0',
+        baseUrl: 'http://localhost:3000/api',
+      });
+
+      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+      expect((openApiDocument.paths['/date']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+        format: 'date-time',
+      });
+      expect((openApiDocument.paths['/date-optional']!.get!.parameters![0]! as any).schema).toEqual(
+        {
+          type: 'string',
+          format: 'date-time',
+        },
+      );
+      expect((openApiDocument.paths['/date-default']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+        format: 'date-time',
+        default: now,
+      });
+      expect(
+        (openApiDocument.paths['/date-preprocess']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        type: 'string',
+        format: 'date-time',
+      });
+      expect((openApiDocument.paths['/date-union']!.get!.parameters![0]! as any).schema).toEqual({
+        anyOf: [
+          { type: 'string', format: 'date-time' },
+          { type: 'string', format: 'date-time' },
+        ],
+      });
+      expect(
+        (openApiDocument.paths['/date-intersection']!.get!.parameters![0]! as any).schema,
+      ).toEqual({
+        allOf: [
+          { type: 'string', format: 'date-time' },
+          { type: 'string', format: 'date-time' },
+        ],
+      });
+      expect((openApiDocument.paths['/date-lazy']!.get!.parameters![0]! as any).schema).toEqual({
+        type: 'string',
+        format: 'date-time',
+      });
+    }
   });
 
   test('with bad method', () => {
@@ -1224,6 +1618,38 @@ describe('generator', () => {
     `);
   });
 
+  test('with refine', () => {
+    const appRouter = trpc.router<any, OpenApiMeta>().query('refine', {
+      meta: { openapi: { enabled: true, path: '/refine', method: 'GET' } },
+      input: z.object({
+        age: z.string().refine((input) => parseInt(input) < 18, { message: 'Too young' }),
+      }),
+      output: z.number(),
+      resolve: ({ input }) => parseInt(input.age),
+    });
+
+    const openApiDocument = generateOpenApiDocument(appRouter, {
+      title: 'tRPC OpenAPI',
+      version: '1.0.0',
+      baseUrl: 'http://localhost:3000/api',
+    });
+
+    expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+    expect(openApiDocument.paths['/refine']!.get!.parameters).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": undefined,
+          "in": "query",
+          "name": "age",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+        },
+      ]
+    `);
+  });
+
   test('with preprocess', () => {
     const appRouter = trpc.router<any, OpenApiMeta>().query('preprocess', {
       meta: { openapi: { enabled: true, path: '/preprocess', method: 'GET' } },
@@ -1315,7 +1741,7 @@ describe('generator', () => {
     ]);
   });
 
-  test('with schema descriptions', () => {
+  test('with schema description', () => {
     const appRouter = trpc
       .router<any, OpenApiMeta>()
       .mutation('createUser', {
@@ -1566,231 +1992,85 @@ describe('generator', () => {
     `);
   });
 
-  ///////
+  test('with record', () => {
+    const appRouter = trpc.router<any, OpenApiMeta>().query('record', {
+      meta: { openapi: { enabled: true, path: '/record', method: 'GET' } },
+      input: z.record(z.string()),
+      output: z.void(),
+      resolve: () => undefined,
+    });
 
-  test('with object enum value query input', () => {
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('enum', {
-        meta: { openapi: { enabled: true, path: '/enum', method: 'GET' } },
-        // @ts-expect-error - intentional number in enum
-        input: z.object({ name: z.enum([1234, 5678]) }),
-        output: z.null(),
-        resolve: () => null,
-      });
-
-      expect(() => {
-        generateOpenApiDocument(appRouter, {
-          title: 'tRPC OpenAPI',
-          version: '1.0.0',
-          baseUrl: 'http://localhost:3000/api',
-        });
-      }).toThrowError('[query.enum] - Input parser key: "name" must be ZodParameterType');
-    }
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('enum', {
-        meta: { openapi: { enabled: true, path: '/enum', method: 'GET' } },
-        input: z.object({ name: z.enum(['James', 'jlalmes']) }),
-        output: z.null(),
-        resolve: () => null,
-      });
-
-      const openApiDocument = generateOpenApiDocument(appRouter, {
+    expect(() => {
+      generateOpenApiDocument(appRouter, {
         title: 'tRPC OpenAPI',
         version: '1.0.0',
         baseUrl: 'http://localhost:3000/api',
       });
-
-      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-      expect(openApiDocument.paths['/enum']!.get!.parameters).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "description": undefined,
-            "in": "query",
-            "name": "name",
-            "required": true,
-            "schema": Object {
-              "enum": Array [
-                "James",
-                "jlalmes",
-              ],
-              "type": "string",
-            },
-          },
-        ]
-      `);
-    }
+    }).toThrowError('[query.record] - Input parser must be a ZodObject');
   });
 
-  test('with object native-enum value query input', () => {
-    {
-      enum InvalidEnum {
-        James,
-        jlalmes,
-      }
+  test('with async transform', () => {
+    const appRouter = trpc.router<any, OpenApiMeta>().query('asyncTransform', {
+      meta: { openapi: { enabled: true, path: '/async-transform', method: 'GET' } },
+      input: z.object({
+        age: z.string().transform(async (input) => {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return parseInt(input);
+        }),
+      }),
+      output: z.object({ age: z.number() }),
+      resolve: ({ input }) => ({ age: input.age }),
+    });
 
-      const appRouter = trpc.router<any, OpenApiMeta>().query('nativeEnum', {
-        meta: { openapi: { enabled: true, path: '/nativeEnum', method: 'GET' } },
-        input: z.object({ name: z.nativeEnum(InvalidEnum) }),
-        output: z.null(),
-        resolve: () => null,
-      });
+    const openApiDocument = generateOpenApiDocument(appRouter, {
+      title: 'tRPC OpenAPI',
+      version: '1.0.0',
+      baseUrl: 'http://localhost:3000/api',
+    });
 
-      expect(() => {
-        generateOpenApiDocument(appRouter, {
-          title: 'tRPC OpenAPI',
-          version: '1.0.0',
-          baseUrl: 'http://localhost:3000/api',
-        });
-      }).toThrowError('[query.nativeEnum] - Input parser key: "name" must be ZodParameterType');
-    }
-    {
-      enum ValidEnum {
-        James = 'James',
-        jlalmes = 'jlalmes',
-      }
-
-      const appRouter = trpc.router<any, OpenApiMeta>().query('nativeEnum', {
-        meta: { openapi: { enabled: true, path: '/nativeEnum', method: 'GET' } },
-        input: z.object({ name: z.nativeEnum(ValidEnum) }),
-        output: z.null(),
-        resolve: () => null,
-      });
-
-      const openApiDocument = generateOpenApiDocument(appRouter, {
-        title: 'tRPC OpenAPI',
-        version: '1.0.0',
-        baseUrl: 'http://localhost:3000/api',
-      });
-
-      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-      expect(openApiDocument.paths['/nativeEnum']!.get!.parameters).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "description": undefined,
-            "in": "query",
-            "name": "name",
-            "required": true,
-            "schema": Object {
-              "enum": Array [
-                "James",
-                "jlalmes",
-              ],
-              "type": "string",
-            },
+    expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+    expect(openApiDocument.paths['/async-transform']!.get!.parameters).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": undefined,
+          "in": "query",
+          "name": "age",
+          "required": true,
+          "schema": Object {
+            "type": "string",
           },
-        ]
-      `);
-    }
+        },
+      ]
+    `);
   });
 
-  // FIXME: skipped
-  test.skip('with object literal value query input', () => {
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('numberLiteral', {
-        meta: { openapi: { enabled: true, path: '/number-literal', method: 'GET' } },
-        input: z.object({ num: z.literal(123) }),
-        output: z.object({ num: z.literal(123) }),
-        resolve: () => ({ num: 123 as const }),
-      });
+  test('with lazy', () => {
+    const appRouter = trpc.router<any, OpenApiMeta>().query('lazy', {
+      meta: { openapi: { enabled: true, path: '/lazy', method: 'GET' } },
+      input: z.object({ name: z.lazy(() => z.string()) }),
+      output: z.object({ name: z.string() }),
+      resolve: ({ input }) => ({ name: input.name }),
+    });
 
-      expect(() => {
-        generateOpenApiDocument(appRouter, {
-          title: 'tRPC OpenAPI',
-          version: '1.0.0',
-          baseUrl: 'http://localhost:3000/api',
-        });
-      }).toThrowError('[query.numberLiteral] - Input parser key: "num" must be ZodStringxxx');
-    }
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('stringLiteral', {
-        meta: { openapi: { enabled: true, path: '/string-literal', method: 'GET' } },
-        input: z.object({ str: z.literal('strlitval') }),
-        output: z.object({ str: z.literal('strlitval') }),
-        resolve: () => ({ str: 'strlitval' as const }),
-      });
+    const openApiDocument = generateOpenApiDocument(appRouter, {
+      title: 'tRPC OpenAPI',
+      version: '1.0.0',
+      baseUrl: 'http://localhost:3000/api',
+    });
 
-      const openApiDocument = generateOpenApiDocument(appRouter, {
-        title: 'tRPC OpenAPI',
-        version: '1.0.0',
-        baseUrl: 'http://localhost:3000/api',
-      });
-
-      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-      expect(openApiDocument.paths['/string-literal']!.get!.parameters).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "description": undefined,
-            "in": "query",
-            "name": "str",
-            "required": true,
-            "schema": Object {
-              "enum": Array [
-                "strlitval",
-              ],
-              "type": "string",
-            },
+    expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+    expect(openApiDocument.paths['/lazy']!.get!.parameters).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": undefined,
+          "in": "query",
+          "name": "name",
+          "required": true,
+          "schema": Object {
+            "type": "string",
           },
-        ]
-      `);
-    }
-  });
-
-  // FIXME: skipped
-  test.skip('with object union value query input', () => {
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('union', {
-        meta: { openapi: { enabled: true, path: '/union', method: 'GET' } },
-        input: z.object({ name: z.string().or(z.number()) }),
-        output: z.null(),
-        resolve: () => null,
-      });
-
-      expect(() => {
-        generateOpenApiDocument(appRouter, {
-          title: 'tRPC OpenAPI',
-          version: '1.0.0',
-          baseUrl: 'http://localhost:3000/api',
-        });
-      }).toThrowError('[query.union] - Input parser key: "name" must be ZodStringxxx');
-    }
-    {
-      const appRouter = trpc.router<any, OpenApiMeta>().query('union', {
-        meta: { openapi: { enabled: true, path: '/union', method: 'GET' } },
-        input: z.object({ name: z.string().or(z.literal('James')) }),
-        output: z.null(),
-        resolve: () => null,
-      });
-
-      const openApiDocument = generateOpenApiDocument(appRouter, {
-        title: 'tRPC OpenAPI',
-        version: '1.0.0',
-        baseUrl: 'http://localhost:3000/api',
-      });
-
-      expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
-      expect(openApiDocument.paths['/union']!.get!.parameters).toMatchInlineSnapshot(`
-        Array [
-          Object {
-            "description": undefined,
-            "in": "query",
-            "name": "name",
-            "required": true,
-            "schema": Object {
-              "anyOf": Array [
-                Object {
-                  "type": "string",
-                },
-                Object {
-                  "enum": Array [
-                    "James",
-                  ],
-                  "type": "string",
-                },
-              ],
-            },
-          },
-        ]
-      `);
-    }
+        },
+      ]
+    `);
   });
 });


### PR DESCRIPTION
Seeking some feedback. This PR monkey patches the TRPCRouter to support `number`, `boolean` & `Date` out of the box (`string` was already supported) for `queries` inputs & `pathParameters`. I hope this would improve `trpc-openapi` incremental adoption, but I'm not sure wether I should just close this PR & force just encourage users to use `z.preprocess` instead...?

```ts
// Before PR
.query('some-query', {
  meta: { openapi: {...} },
  input: z.object({ 
    offset: z.preprocess((arg) => {
      if (typeof arg === 'string') return parseInt(arg);
      return arg;
    }, z.number().min(0)), 
    limit: z.preprocess((arg) => {
      if (typeof arg === 'string') return parseInt(arg);
      return arg;
    }, z.number().min(10).max(50)),
  }),
  ...
})
```

```ts
// After PR
.query('some-query', {
  meta: { openapi: {...} },
  input: z.object({ 
    offset: z.number().min(0), 
    limit: z.number().min(10).max(50),
  }),
  ...
})
```