### PR TITLE
fix/requires-tslib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "removeComments": false,
-    "noUncheckedIndexedAccess": true,
-    "importHelpers": true
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
Closes https://github.com/jlalmes/trpc-openapi/issues/54.

## fix/requires-tslib

`tslib` was a required dependency becuase `importHelpers` was enabled.