### PR TITLE
Deprecate `tag` from `OpenApiMeta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ Please see [full typings here](src/types.ts).
 | `protect`     | `boolean`    | Requires this endpoint to use an `Authorization` header credential with `Bearer` scheme on OpenAPI document.       | `false`  | `false`     |
 | `summary`     | `string`     | A short summary of the endpoint included in the OpenAPI document.                                                  | `false`  | `undefined` |
 | `description` | `string`     | A verbose description of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined` |
-| `tag`         | `string`     | A single tag used for logical grouping of endpoints in the OpenAPI document.                                       | `false`  | `undefined` |
 | `tags`        | `string[]`   | A list of tags used for logical grouping of endpoints in the OpenAPI document.                                     | `false`  | `undefined` |
 
 #### CreateOpenApiNodeHttpHandlerOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,18 @@ export type OpenApiMeta<TMeta = Record<string, any>> = TMeta & {
     summary?: string;
     description?: string;
     protect?: boolean;
-  } & ({ tag?: never; tags?: string[] } | { tag?: string; tags?: never });
+  } & (
+    | {
+        tags?: never;
+        /** @deprecated Use `tags` instead */
+        tag?: string;
+      }
+    | {
+        tags?: string[];
+        /** @deprecated Use `tags` instead */
+        tag?: never;
+      }
+  );
 };
 
 export type OpenApiProcedureRecord<TMeta = Record<string, any>> = ProcedureRecord<


### PR DESCRIPTION
## Deprecate `tag` from `OpenApiMeta`

Follow up task from PR https://github.com/jlalmes/trpc-openapi/pull/84.