### PR TITLE
Feat: Support x-www-form-urlencoded request bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Please note:
 
 ## HTTP Requests
 
-Procedures with a `GET`/`DELETE` method will accept inputs via URL `query parameters`. Procedures with a `POST`/`PATCH`/`PUT` method will accept inputs via the `request body` with a `application/json` content type.
+Procedures with a `GET`/`DELETE` method will accept inputs via URL `query parameters`. Procedures with a `POST`/`PATCH`/`PUT` method will accept inputs via the `request body` with a `application/json` or `application/x-www-form-urlencoded` content type.
 
 ### Path parameters
 
@@ -302,16 +302,17 @@ Please see [full typings here](src/generator/index.ts).
 
 Please see [full typings here](src/types.ts).
 
-| Property      | Type                | Description                                                                                                  | Required | Default     |
-| ------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
-| `enabled`     | `boolean`           | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                               | `false`  | `true`      |
-| `method`      | `HttpMethod`        | HTTP method this endpoint is exposed on. Value can be `GET`, `POST`, `PATCH`, `PUT` or `DELETE`.             | `true`   | `undefined` |
-| `path`        | `string`            | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.         | `true`   | `undefined` |
-| `protect`     | `boolean`           | Requires this endpoint to use an `Authorization` header credential with `Bearer` scheme on OpenAPI document. | `false`  | `false`     |
-| `summary`     | `string`            | A short summary of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined` |
-| `description` | `string`            | A verbose description of the endpoint included in the OpenAPI document.                                      | `false`  | `undefined` |
-| `tags`        | `string[]`          | A list of tags used for logical grouping of endpoints in the OpenAPI document.                               | `false`  | `undefined` |
-| `headers`     | `ParameterObject[]` | An array of custom headers to add for this endpoint in the OpenAPI document.                                 | `false`  | `undefined` |
+| Property       | Type                | Description                                                                                                  | Required | Default                |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ | -------- | ---------------------- |
+| `enabled`      | `boolean`           | Exposes this procedure to `trpc-openapi` adapters and on the OpenAPI document.                               | `false`  | `true`                 |
+| `method`       | `HttpMethod`        | HTTP method this endpoint is exposed on. Value can be `GET`, `POST`, `PATCH`, `PUT` or `DELETE`.             | `true`   | `undefined`            |
+| `path`         | `string`            | Pathname this endpoint is exposed on. Value must start with `/`, specify path parameters using `{}`.         | `true`   | `undefined`            |
+| `protect`      | `boolean`           | Requires this endpoint to use an `Authorization` header credential with `Bearer` scheme on OpenAPI document. | `false`  | `false`                |
+| `summary`      | `string`            | A short summary of the endpoint included in the OpenAPI document.                                            | `false`  | `undefined`            |
+| `description`  | `string`            | A verbose description of the endpoint included in the OpenAPI document.                                      | `false`  | `undefined`            |
+| `tags`         | `string[]`          | A list of tags used for logical grouping of endpoints in the OpenAPI document.                               | `false`  | `undefined`            |
+| `headers`      | `ParameterObject[]` | An array of custom headers to add for this endpoint in the OpenAPI document.                                 | `false`  | `undefined`            |
+| `contentTypes` | `ContentType[]`     | A set of content types specified as accepted in the OpenAPI document.                                        | `false`  | `['application/json']` |
 
 #### CreateOpenApiNodeHttpHandlerOptions
 

--- a/src/adapters/node-http/input.ts
+++ b/src/adapters/node-http/input.ts
@@ -41,9 +41,9 @@ export const getBody = async (req: NodeHTTPRequest, maxBodySize = BODY_100_KB): 
 
   req.body = undefined;
 
-  if (req.headers['content-type'] === 'application/json') {
+  if (req.headers['content-type']) {
     try {
-      const { raw, parsed } = await parse.json(req, {
+      const { raw, parsed } = await parse(req, {
         limit: maxBodySize,
         strict: false,
         returnRawBody: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export type OpenApiMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
 type TRPCMeta = Record<string, unknown>;
 
+export type OpenApiContentType = 'application/json' | 'application/x-www-form-urlencoded';
+
 export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
   openapi?: {
     enabled?: boolean;
@@ -18,6 +20,7 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     protect?: boolean;
     tags?: string[];
     headers?: (OpenAPIV3.ParameterBaseObject & { name: string; in?: 'header' })[];
+    contentTypes?: OpenApiContentType[];
   };
 };
 

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -1697,6 +1697,45 @@ describe('generator', () => {
     `);
   });
 
+  test('with coerce', () => {
+    const appRouter = t.router({
+      transform: t.procedure
+        .meta({ openapi: { method: 'GET', path: '/coerce' } })
+        .input(z.object({ payload: z.number() }))
+        .output(z.number())
+        .query(({ input }) => input.payload),
+    });
+
+    const openApiDocument = generateOpenApiDocument(appRouter, defaultDocOpts);
+
+    expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+    expect(openApiDocument.paths['/coerce']!.get!.parameters).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "description": undefined,
+          "in": "query",
+          "name": "payload",
+          "required": true,
+          "schema": Object {
+            "type": "number",
+          },
+        },
+      ]
+    `);
+    expect(openApiDocument.paths['/coerce']!.get!.responses[200]).toMatchInlineSnapshot(`
+      Object {
+        "content": Object {
+          "application/json": Object {
+            "schema": Object {
+              "type": "number",
+            },
+          },
+        },
+        "description": "Successful response",
+      }
+    `);
+  });
+
   test('with union', () => {
     {
       const appRouter = t.router({


### PR DESCRIPTION
Closes https://github.com/jlalmes/trpc-openapi/issues/187

## Feat: Support `application/x-www-form-urlencoded` Content-Type.

Added `contentTypes` parameter to the `OpenApiMeta` for each procedure. (Defaults to `["application/json"]`).

#### Examples

```ts
// support only `x-www-form-urlencoded`
.meta({
  openapi: {
    method: 'POST',
    path: '/echo',
    contentTypes: [
      'application/x-www-form-urlencoded'
    ],
  },
})

// support `application/json` and `x-www-form-urlencoded`
.meta({
  openapi: {
    method: 'POST',
    path: '/echo',
    contentTypes: [
      'application/json',
      'application/x-www-form-urlencoded'
    ],
  },
})

// defaults to `application/json`
.meta({
  openapi: {
    method: 'POST',
    path: '/echo',
  },
})
```