### PR TITLE
Fix: coerce all input values regardless of query/body/path

### DIFF
--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -113,8 +113,8 @@ export const createOpenApiNodeHttpHandler = <
         };
       }
 
-      // if query & supported, coerce all string values to correct types
-      if (!useBody && zodSupportsCoerce) {
+      // if supported, coerce all string values to correct types
+      if (zodSupportsCoerce) {
         if (instanceofZodTypeObject(unwrappedSchema)) {
           Object.values(unwrappedSchema.shape).forEach((shapeSchema) => {
             const unwrappedShapeSchema = unwrapZodType(shapeSchema, false);


### PR DESCRIPTION
Closes: https://github.com/jlalmes/trpc-openapi/issues/243 & https://github.com/jlalmes/trpc-openapi/issues/242