### PR TITLE
Add support for marking an endpoint as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Please see [full typings here](src/types.ts).
 | `tags`         | `string[]`          | A list of tags used for logical grouping of endpoints in the OpenAPI document.                               | `false`  | `undefined`            |
 | `headers`      | `ParameterObject[]` | An array of custom headers to add for this endpoint in the OpenAPI document.                                 | `false`  | `undefined`            |
 | `contentTypes` | `ContentType[]`     | A set of content types specified as accepted in the OpenAPI document.                                        | `false`  | `['application/json']` |
+| `deprecated`   | `boolean`           | Whether or not to mark an endpoint as deprecated                                                             | `false`  | `false`                |
 
 #### CreateOpenApiNodeHttpHandlerOptions
 

--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -79,6 +79,7 @@ export const getOpenApiPathsObject = (
                 ],
               }),
           responses: getResponsesObject(outputParser),
+          ...(openapi.deprecated ? { deprecated: openapi.deprecated } : {}),
         },
       };
     } catch (error: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
     tags?: string[];
     headers?: (OpenAPIV3.ParameterBaseObject & { name: string; in?: 'header' })[];
     contentTypes?: OpenApiContentType[];
+    deprecated?: boolean;
   };
 };
 


### PR DESCRIPTION
Quite a simple change - just passes through the `deprecated` setting when it's set