### PR TITLE
Verify that URL parameters do not conflict with request input

### DIFF
--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -107,8 +107,17 @@ export const createOpenApiNodeHttpHandler = <
 
       // input should stay undefined if z.void()
       if (!instanceofZodTypeLikeVoid(unwrappedSchema)) {
+        const extraParams = useBody ? await getBody(req, maxBodySize) : getQuery(req, url)
+        for (const key in pathInput) {
+          if (extraParams[key] !== undefined && pathInput[key] !== extraParams[key]) {
+            throw new TRPCError({
+              message: `Cannot provide different values for ${key} via URL and request ${useBody ? "body" : "query parameters"}`,
+              code: "BAD_REQUEST",
+            })
+          }
+        }
         input = {
-          ...(useBody ? await getBody(req, maxBodySize) : getQuery(req, url)),
+          ...extraParams,
           ...pathInput,
         };
       }

--- a/test/adapters/standalone.test.ts
+++ b/test/adapters/standalone.test.ts
@@ -772,11 +772,14 @@ describe('standalone adapter', () => {
       });
       const body = await res.json();
 
-      expect(res.status).toBe(200);
-      expect(body).toEqual({ greeting: 'Hello James!' });
-      expect(createContextMock).toHaveBeenCalledTimes(1);
+      expect(res.status).toBe(400);
+      expect(body).toEqual({
+        message: 'Cannot provide different values for name via URL and request body',
+        code: 'BAD_REQUEST',
+      });
+      expect(createContextMock).toHaveBeenCalledTimes(0);
       expect(responseMetaMock).toHaveBeenCalledTimes(1);
-      expect(onErrorMock).toHaveBeenCalledTimes(0);
+      expect(onErrorMock).toHaveBeenCalledTimes(1);
 
       clearMocks();
     }
@@ -786,11 +789,30 @@ describe('standalone adapter', () => {
       });
       const body = await res.json();
 
+      expect(res.status).toBe(400);
+      expect(body).toEqual({
+        message: 'Cannot provide different values for first via URL and request query parameters',
+        code: 'BAD_REQUEST',
+      });
+      expect(createContextMock).toHaveBeenCalledTimes(0);
+      expect(responseMetaMock).toHaveBeenCalledTimes(1);
+      expect(onErrorMock).toHaveBeenCalledTimes(1);
+
+      clearMocks();
+    }
+    {
+      const res = await fetch(`${url}/say-hello/James/Berry?greeting=Hello&first=James`, {
+        method: 'GET',
+      });
+      const body = await res.json();
+
       expect(res.status).toBe(200);
       expect(body).toEqual({ greeting: 'Hello James Berry!' });
       expect(createContextMock).toHaveBeenCalledTimes(1);
       expect(responseMetaMock).toHaveBeenCalledTimes(1);
       expect(onErrorMock).toHaveBeenCalledTimes(0);
+
+      clearMocks();
     }
 
     close();


### PR DESCRIPTION
This change makes it so that when values are provided both as path parameters and via the request body or query parameters, we check that the values are equal, and if they aren't we throw an error. There should be no error if both are provided but are also equal.

I've used a simple `===` (or rather `!==`) to check given path parameters should be simple types, but if this logic needs to be improved to handle cases where zod preprocess is used, please let me know

This is a change from existing behaviour (as can be seen by the changes in the tests), but I think it's a useful one, or at least an improvement on silently overwriting information from the request body