### PR TITLE
OpenAPI Error Response should be called `error`, not `default`

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -192,7 +192,7 @@ export const getResponsesObject = (schema: unknown): OpenAPIV3.ResponsesObject =
 
   return {
     200: successResponseObject,
-    default: {
+    error: {
       $ref: '#/components/responses/error',
     },
   };

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -587,7 +587,7 @@ describe('generator', () => {
                   },
                   "description": "Successful response",
                 },
-                "default": Object {
+                "error": Object {
                   "$ref": "#/components/responses/error",
                 },
               },
@@ -642,7 +642,7 @@ describe('generator', () => {
                   },
                   "description": "Successful response",
                 },
-                "default": Object {
+                "error": Object {
                   "$ref": "#/components/responses/error",
                 },
               },
@@ -676,7 +676,7 @@ describe('generator', () => {
                   },
                   "description": "Successful response",
                 },
-                "default": Object {
+                "error": Object {
                   "$ref": "#/components/responses/error",
                 },
               },
@@ -723,7 +723,7 @@ describe('generator', () => {
                   },
                   "description": "Successful response",
                 },
-                "default": Object {
+                "error": Object {
                   "$ref": "#/components/responses/error",
                 },
               },
@@ -785,7 +785,7 @@ describe('generator', () => {
                   },
                   "description": "Successful response",
                 },
-                "default": Object {
+                "error": Object {
                   "$ref": "#/components/responses/error",
                 },
               },
@@ -962,7 +962,7 @@ describe('generator', () => {
             },
             "description": "Successful response",
           },
-          "default": Object {
+          "error": Object {
             "$ref": "#/components/responses/error",
           },
         },
@@ -1016,7 +1016,7 @@ describe('generator', () => {
             },
             "description": "Successful response",
           },
-          "default": Object {
+          "error": Object {
             "$ref": "#/components/responses/error",
           },
         },
@@ -2329,7 +2329,7 @@ describe('generator', () => {
                 },
                 "description": "Successful response",
               },
-              "default": Object {
+              "error": Object {
                 "$ref": "#/components/responses/error",
               },
             },
@@ -2374,7 +2374,7 @@ describe('generator', () => {
                 },
                 "description": "Successful response",
               },
-              "default": Object {
+              "error": Object {
                 "$ref": "#/components/responses/error",
               },
             },
@@ -2419,7 +2419,7 @@ describe('generator', () => {
                 },
                 "description": "Successful response",
               },
-              "default": Object {
+              "error": Object {
                 "$ref": "#/components/responses/error",
               },
             },


### PR DESCRIPTION
As you port your tRPC OpenAPI spec files to documentation generators, it looks like the default response is the error one. I think it would be more clear to just call this `error` vs. `default`. 

Example in the popular API Docs service, Readme.

<img src="https://user-images.githubusercontent.com/58447835/235320653-009434cc-364b-4cef-924f-adfe6d46d64a.png" width=400 />
