### PR TITLE
Remove requirement of input and output types

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -26,10 +26,7 @@ export const getParameterObjects = (
   inType: 'all' | 'path' | 'query',
 ): OpenAPIV3.ParameterObject[] | undefined => {
   if (!instanceofZodType(schema)) {
-    throw new TRPCError({
-      message: 'Input parser expects a Zod validator',
-      code: 'INTERNAL_SERVER_ERROR',
-    });
+    schema = z.void();
   }
 
   const isRequired = !schema.isOptional();
@@ -117,10 +114,7 @@ export const getRequestBodyObject = (
   contentTypes: OpenApiContentType[],
 ): OpenAPIV3.RequestBodyObject | undefined => {
   if (!instanceofZodType(schema)) {
-    throw new TRPCError({
-      message: 'Input parser expects a Zod validator',
-      code: 'INTERNAL_SERVER_ERROR',
-    });
+    schema = z.void();
   }
 
   const isRequired = !schema.isOptional();
@@ -175,10 +169,7 @@ export const errorResponseObject = {
 
 export const getResponsesObject = (schema: unknown): OpenAPIV3.ResponsesObject => {
   if (!instanceofZodType(schema)) {
-    throw new TRPCError({
-      message: 'Output parser expects a Zod validator',
-      code: 'INTERNAL_SERVER_ERROR',
-    });
+    schema = z.any();
   }
 
   const successResponseObject = {


### PR DESCRIPTION
Would you entertain something like this? We have a pretty large tRPC backend that is inferring output types right now, and some of the openapi inputs require no input so this change seems nicer then having to provide `z.void()` in those situations. Seeing that tRPC doesn't require an input I don't think the openapi add on should either.

Merging something like this would allow a user to skip the input and output completely if their endpoint took no input and they did not want to type the output for openapi. Understanding they would lose doc support and zod protection of their outputs. 

We are doing this here rather then providing `z.any()` in our output as we want to keep the inferred types for the tRPC api, when we open this up for a basic REST api though we are not as concerned with forcing our outputs to be a specific format.