### PR TITLE
add "securitySchemes" to generateOpenApiDocumentation options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 dist
 .DS_Store
-pnpm-lock.yaml

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -13,12 +13,24 @@ export type GenerateOpenApiDocumentOptions = {
   baseUrl: string;
   docsUrl?: string;
   tags?: string[];
+  securitySchemes?: {
+    [key: string]: OpenAPIV3.ReferenceObject | OpenAPIV3.SecuritySchemeObject;
+  };
 };
 
 export const generateOpenApiDocument = (
   appRouter: OpenApiRouter,
   opts: GenerateOpenApiDocumentOptions,
 ): OpenAPIV3.Document => {
+  const {
+    securitySchemes = {
+      Authorization: {
+        type: 'http',
+        scheme: 'bearer',
+      },
+    },
+  } = opts;
+
   return {
     openapi: openApiVersion,
     info: {
@@ -33,12 +45,7 @@ export const generateOpenApiDocument = (
     ],
     paths: getOpenApiPathsObject(appRouter, {}),
     components: {
-      securitySchemes: {
-        Authorization: {
-          type: 'http',
-          scheme: 'bearer',
-        },
-      },
+      securitySchemes,
       responses: {
         error: errorResponseObject,
       },

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -13,24 +13,13 @@ export type GenerateOpenApiDocumentOptions = {
   baseUrl: string;
   docsUrl?: string;
   tags?: string[];
-  securitySchemes?: {
-    [key: string]: OpenAPIV3.ReferenceObject | OpenAPIV3.SecuritySchemeObject;
-  };
+  securitySchemes?: OpenAPIV3.ComponentsObject['securitySchemes'];
 };
 
 export const generateOpenApiDocument = (
   appRouter: OpenApiRouter,
   opts: GenerateOpenApiDocumentOptions,
 ): OpenAPIV3.Document => {
-  const {
-    securitySchemes = {
-      Authorization: {
-        type: 'http',
-        scheme: 'bearer',
-      },
-    },
-  } = opts;
-
   return {
     openapi: openApiVersion,
     info: {
@@ -45,7 +34,12 @@ export const generateOpenApiDocument = (
     ],
     paths: getOpenApiPathsObject(appRouter, {}),
     components: {
-      securitySchemes,
+      securitySchemes: opts.securitySchemes || {
+        Authorization: {
+          type: 'http',
+          scheme: 'bearer',
+        },
+      },
       responses: {
         error: errorResponseObject,
       },

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -2568,12 +2568,38 @@ describe('generator', () => {
         (openApiDocument.paths['/with-all']!.post!.requestBody as any).content['application/json'],
       ).toEqual(
         (openApiDocument.paths['/with-all']!.post!.requestBody as any).content[
-          'application/x-www-form-urlencoded'
+        'application/x-www-form-urlencoded'
         ],
       );
       expect(
         Object.keys((openApiDocument.paths['/with-default']!.post!.requestBody as any).content),
       ).toEqual(['application/json']);
     }
+  });
+
+  test('with security schemes', () => {
+    const appRouter = t.router({});
+
+    const openApiDocument = generateOpenApiDocument(appRouter, {
+      title: 'tRPC OpenAPI',
+      version: '1.0.0',
+      baseUrl: 'http://localhost:3000/api',
+      securitySchemes: {
+        ApiKey: {
+          type: 'apiKey',
+          in: 'header',
+          name: 'X-API-Key',
+        },
+      },
+    });
+
+    expect(openApiSchemaValidator.validate(openApiDocument).errors).toEqual([]);
+    expect(openApiDocument.components!.securitySchemes).toEqual({
+      ApiKey: {
+        type: 'apiKey',
+        in: 'header',
+        name: 'X-API-Key',
+      },
+    });
   });
 });


### PR DESCRIPTION
So we can use other security schemes (such as `ApiKey`, `OpenID`,...) other than `http` (for `Basic`, `Bearer`)

## Examples

```typescript
const openApiDocument = generateOpenApiDocument(appRouter, {
  title: 'tRPC OpenAPI',
  version: '1.0.0',
  description: 'API documentation',
  baseUrl: 'http://localhost:3000/api',
  docsUrl: 'http://localhost:3000/docs',
  tags: [],
  securitySchemes = {
    // default
    Authorization: {
      type: 'http',
      scheme: 'bearer',
    },
    // additional schemes
    ApiKey: {
      type: 'apiKey'
      in: 'header'
      name: 'X-API-Key'
    }
  },
});
```

## Ref
https://swagger.io/docs/specification/authentication/

## Related issues

- https://github.com/jlalmes/trpc-openapi/issues/290