### PR TITLE
fix: Lambda adapter supports application/x-www-form-urlencoded

### DIFF
--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -64,7 +64,6 @@ const createMockNodeHTTPRequest = (path: string, event: APIGatewayEvent): NodeHT
     try {
       if (event.body) {
         const bodyParams = new URLSearchParams(event.body);
-        console.log({ bodyParams });
         body = {} as Record<string, unknown>;
         for (const [key, value] of bodyParams.entries()) {
           body[key] = value;

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -63,9 +63,12 @@ const createMockNodeHTTPRequest = (path: string, event: APIGatewayEvent): NodeHT
   if (contentType === 'application/x-www-form-urlencoded') {
     try {
       if (event.body) {
-        const bodyParams = new URLSearchParams(event.body);
+        const searchParamsString = event.isBase64Encoded
+          ? Buffer.from(event.body, 'base64').toString('utf-8')
+          : event.body;
+        const searchParams = new URLSearchParams(searchParamsString);
         body = {} as Record<string, unknown>;
-        for (const [key, value] of bodyParams.entries()) {
+        for (const [key, value] of searchParams.entries()) {
           body[key] = value;
         }
       }

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -60,6 +60,24 @@ const createMockNodeHTTPRequest = (path: string, event: APIGatewayEvent): NodeHT
       });
     }
   }
+  if (contentType === 'application/x-www-form-urlencoded') {
+    try {
+      if (event.body) {
+        const bodyParams = new URLSearchParams(event.body);
+        console.log({ bodyParams });
+        body = {} as Record<string, unknown>;
+        for (const [key, value] of bodyParams.entries()) {
+          body[key] = value;
+        }
+      }
+    } catch (cause) {
+      throw new TRPCError({
+        message: 'Failed to parse request body',
+        code: 'PARSE_ERROR',
+        cause,
+      });
+    }
+  }
 
   return createRequest({
     url,

--- a/test/adapters/aws-lambda.test.ts
+++ b/test/adapters/aws-lambda.test.ts
@@ -84,7 +84,7 @@ describe('v1', () => {
     });
   });
 
-  test('with body input', async () => {
+  test('with JSON body input', async () => {
     const {
       statusCode,
       headers,
@@ -96,6 +96,35 @@ describe('v1', () => {
         }),
         headers: {
           'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        path: 'hello',
+        queryStringParameters: {},
+        resource: '/hello',
+      }),
+      ctx,
+    );
+    const body = JSON.parse(rawBody);
+
+    expect(statusCode).toBe(200);
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+    });
+    expect(body).toEqual({
+      greeting: 'Hello Aphex',
+    });
+  });
+
+  test('with url encoded body input', async () => {
+    const {
+      statusCode,
+      headers,
+      body: rawBody,
+    } = await handler(
+      mockAPIGatewayProxyEventV1({
+        body: 'name=Aphex',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
         },
         method: 'POST',
         path: 'hello',
@@ -275,7 +304,7 @@ describe('v2', () => {
     });
   });
 
-  test('with body input', async () => {
+  test('with JSON body input', async () => {
     const {
       statusCode,
       headers,
@@ -287,6 +316,35 @@ describe('v2', () => {
         }),
         headers: {
           'content-type': 'application/json',
+        },
+        method: 'POST',
+        path: 'hello',
+        queryStringParameters: {},
+        routeKey: '$default',
+      }),
+      ctx,
+    );
+    const body = JSON.parse(rawBody);
+
+    expect(statusCode).toBe(200);
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+    });
+    expect(body).toEqual({
+      greeting: 'Hello Aphex',
+    });
+  });
+
+  test('with url encoded body input', async () => {
+    const {
+      statusCode,
+      headers,
+      body: rawBody,
+    } = await handler(
+      mockAPIGatewayProxyEventV2({
+        body: 'name=Aphex',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
         },
         method: 'POST',
         path: 'hello',


### PR DESCRIPTION
The `application/x-www-form-urlencoded` content type wasn't supported with Lambda adapter.

I couldn't reuse logic from node-http because AWS Lambda process request differently.

I use URLSearchParams to parse the string received in API Gateway event, then I loop over parsed values to populate the request body as JSON.