### PR TITLE
FIX: Query support on Nuxt Adapter

### DIFF
--- a/src/adapters/nuxt.ts
+++ b/src/adapters/nuxt.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import type { NodeIncomingMessage, NodeServerResponse } from 'h3';
-import { defineEventHandler } from 'h3';
+import { defineEventHandler, getQuery } from 'h3';
+import { IncomingMessage } from 'http';
 
 import { OpenApiErrorResponse, OpenApiRouter } from '../types';
 import { normalizePath } from '../utils/path';
@@ -13,6 +14,10 @@ export type CreateOpenApiNuxtHandlerOptions<TRouter extends OpenApiRouter> = Omi
   CreateOpenApiNodeHttpHandlerOptions<TRouter, NodeIncomingMessage, NodeServerResponse>,
   'maxBodySize'
 >;
+
+type NuxtRequest = IncomingMessage & {
+  query?: ReturnType<typeof getQuery>;
+};
 
 export const createOpenApiNuxtHandler = <TRouter extends OpenApiRouter>(
   opts: CreateOpenApiNuxtHandlerOptions<TRouter>,
@@ -57,6 +62,7 @@ export const createOpenApiNuxtHandler = <TRouter extends OpenApiRouter>(
       return;
     }
 
+    (event.node.req as NuxtRequest).query = getQuery(event);
     event.node.req.url = normalizePath(pathname);
     await openApiHttpHandler(event.node.req, event.node.res);
   });

--- a/test/adapters/nuxt.test.ts
+++ b/test/adapters/nuxt.test.ts
@@ -36,7 +36,7 @@ const createOpenApiNuxtHandlerCaller = <TRouter extends OpenApiRouter>(
   return (req: {
     method: RequestMethod;
     params: Record<string, string>;
-    query?: Record<string, string>;
+    url?: string;
     body?: any;
   }) =>
     new Promise<{
@@ -59,7 +59,7 @@ const createOpenApiNuxtHandlerCaller = <TRouter extends OpenApiRouter>(
       const mockReq = httpMocks.createRequest({
         body: req.body,
         method: req.method,
-        query: req.query,
+        url: req.url,
       });
       const mockRes = httpMocks.createResponse({
         req: mockReq,
@@ -115,7 +115,7 @@ describe('nuxt adapter', () => {
       const res = await openApiNuxtHandlerCaller({
         method: 'GET',
         params: { trpc: 'say-hello' },
-        query: { name: 'James' },
+        url: '/api/say-hello?name=James',
       });
 
       expect(res.statusCode).toBe(200);
@@ -145,7 +145,7 @@ describe('nuxt adapter', () => {
       const res = await openApiNuxtHandlerCaller({
         method: 'GET',
         params: { trpc: 'say/hello' },
-        query: { name: 'James' },
+        url: '/api/say/hello?name=James',
       });
 
       expect(res.statusCode).toBe(200);


### PR DESCRIPTION
In the current implementation on `master` request like:
```sh
curl 'http://localhost:3000/api/posts?userId=<ID>'
```

didn't actually work due to the fact that in Nuxt you need to pull the query params using `getQuery()`.

This PR fixes this issue together with the uni-tests that didn't really cover this case in reality.

Please let me know if something should be revised @jlalmes 