### PR TITLE
fix: Code in README not executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export const appRouter = t.router({
     .output(z.object({ greeting: z.string() }))
     .query(({ input }) => {
       return { greeting: `Hello ${input.name}!` };
-    })
+    }),
 });
 ```
 
@@ -136,7 +136,7 @@ export const appRouter = t.router({
     .output(z.object({ greeting: z.string() }))
     .query(({ input }) => {
       return { greeting: `${input.greeting} ${input.name}!` };
-    });
+    }),
 });
 
 // Client
@@ -157,7 +157,7 @@ export const appRouter = t.router({
     .output(z.object({ greeting: z.string() }))
     .mutation(({ input }) => {
       return { greeting: `${input.greeting} ${input.name}!` };
-    });
+    }),
 });
 
 // Client

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ export const appRouter = t.router({
     .output(z.object({ greeting: z.string() }))
     .query(({ input }) => {
       return { greeting: `Hello ${input.name}!` };
-    });
+    })
 });
 ```
 


### PR DESCRIPTION
The demo route code from the README was not executable due to a misplaced semicolon