### PR TITLE
fix: update @trpc/server imports to use dist

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Procedure, ProcedureParams, Router } from '@trpc/server';
 import type { RootConfig } from '@trpc/server/dist/core/internals/config';
-import { TRPC_ERROR_CODE_KEY } from '@trpc/server/rpc';
-import type { RouterDef } from '@trpc/server/src/core/router';
+import type { RouterDef } from '@trpc/server/dist/core/router';
+import { TRPC_ERROR_CODE_KEY } from '@trpc/server/dist/rpc';
 import { OpenAPIV3 } from 'openapi-types';
 import { ZodIssue } from 'zod';
 


### PR DESCRIPTION
TRPC ships with its src .ts files. There are sneaky imports in this lib that were accidentally targeting TRPC ts, and not the dist files, making it so the whole `@trpc/server` lib was getting checked by the consumer's tsc build! 

In particular, this surfaced for me because my project has `verbatimModuleSyntax` set to `true`, and trpc does not lean on that option.

Thanks for this nifty lib and let me know how else I can help
---
For anyone else coming across this, I'll be monkey patching with yarn until it gets shipped: https://yarnpkg.com/cli/patch