### PR TITLE
feat: `excludeFromSpecFile` option in openapi object

### DIFF
--- a/src/generator/paths.ts
+++ b/src/generator/paths.ts
@@ -15,6 +15,8 @@ export const getOpenApiPathsObject = (
   const procedures = appRouter._def.procedures as OpenApiProcedureRecord;
 
   forEachOpenApiProcedure(procedures, ({ path: procedurePath, type, procedure, openapi }) => {
+    if (openapi.excludeFromSpecFile === true) return;
+
     const procedureName = `${type}.${procedurePath}`;
 
     try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type OpenApiMeta<TMeta = TRPCMeta> = TMeta & {
       response?: Record<string, any>;
     };
     responseHeaders?: Record<string, OpenAPIV3.HeaderObject | OpenAPIV3.ReferenceObject>;
+    excludeFromSpecFile?: boolean;
   };
 };
 


### PR DESCRIPTION
Super useful to still have a working API path but you don't want to have it in the generated OpenAPI document.