### PR TITLE
fix: fastify ERR_HTTP_HEADERS_SENT is reply is not awaited

### DIFF
--- a/src/adapters/node-http/core.ts
+++ b/src/adapters/node-http/core.ts
@@ -70,7 +70,7 @@ export const createOpenApiNodeHttpHandler = <
           res.setHeader(key, value);
         }
       }
-      res.end(JSON.stringify(body));
+      return res.end(JSON.stringify(body));
     };
 
     const method = req.method! as OpenApiMethod & 'HEAD';
@@ -91,8 +91,7 @@ export const createOpenApiNodeHttpHandler = <
 
         // Can be used for warmup
         if (method === 'HEAD') {
-          sendResponse(204, {}, undefined);
-          return;
+          return sendResponse(204, {}, undefined);
         }
 
         throw new TRPCError({
@@ -144,7 +143,7 @@ export const createOpenApiNodeHttpHandler = <
       const statusCode = meta?.status ?? 200;
       const headers = meta?.headers ?? {};
       const body: OpenApiSuccessResponse<typeof data> = data;
-      sendResponse(statusCode, headers, body);
+      return sendResponse(statusCode, headers, body);
     } catch (cause) {
       const error = getErrorFromUnknown(cause);
 
@@ -187,7 +186,7 @@ export const createOpenApiNodeHttpHandler = <
         code: error.code,
         issues: isInputValidationError ? (error.cause as ZodError).errors : undefined,
       };
-      sendResponse(statusCode, headers, body);
+      return sendResponse(statusCode, headers, body);
     }
   };
 };


### PR DESCRIPTION
Hey there,

I was trying to use [trpc-openapi](https://github.com/jlalmes/trpc-openapi) with [fastify-session](https://github.com/mgcrea/fastify-session), and I was wondering why I have `ERR_HTTP_HEADERS_SENT` when sending request to `trpc-openapi`.

I found that `@mgcrea/fastify-session` tried to save multiple times the session.

`fastify` `reply.send` call must be awaited to ensure the request is done.