### PR TITLE
Do not throw an error on undefined schema output

### DIFF
--- a/src/generator/schema.ts
+++ b/src/generator/schema.ts
@@ -189,21 +189,14 @@ export const errorResponseObject: OpenAPIV3.ResponseObject = {
 export const getResponsesObject = (
   schema: unknown,
   example: Record<string, any> | undefined,
-  headers: Record<string, OpenAPIV3.HeaderObject | OpenAPIV3.ReferenceObject> | undefined
+  headers: Record<string, OpenAPIV3.HeaderObject | OpenAPIV3.ReferenceObject> | undefined,
 ): OpenAPIV3.ResponsesObject => {
-  if (!instanceofZodType(schema)) {
-    throw new TRPCError({
-      message: 'Output parser expects a Zod validator',
-      code: 'INTERNAL_SERVER_ERROR',
-    });
-  }
-
   const successResponseObject: OpenAPIV3.ResponseObject = {
     description: 'Successful response',
     headers: headers,
     content: {
       'application/json': {
-        schema: zodSchemaToOpenApiSchemaObject(schema),
+        schema: zodSchemaToOpenApiSchemaObject(instanceofZodType(schema) ? schema : z.unknown()),
         example,
       },
     },


### PR DESCRIPTION
In the case that you don't have the output defined for a particular route, this plugin will throw an error. I believe this should be considered an error because the TRPC documentation states:

In version 9 docs:
"This is entirely optional and only if you want to ensure you don't accidentally leak anything e"
https://trpc.io/docs/v9/output-validation

In version 11 docs:
"Validating outputs is not always as important as defining inputs, since tRPC gives you automatic type-safety by inferring the return type of your procedures. Some reasons to define an output validator include"
https://trpc.io/docs/server/validators#output-validators

So it seems like the definition of an output should be considered optional, and it is not reasonable that an error should be thrown if the output is not defined.

I'm sure there were very well thought out reasons why throwing an error was chosen, so please correct me if I am wrong here or if there is an edge case I am not understanding correctly.